### PR TITLE
Additional test for logistic_regression

### DIFF
--- a/src/ml/regression/logistic.rs
+++ b/src/ml/regression/logistic.rs
@@ -302,8 +302,8 @@ mod tests_logistic_regression {
         // cargo test --release   tests_logistic_regression::test_logistic_regression2 -- --nocapture
 
         // The test generates sample data in the following way:
-        // - For each of the N samples (train/test) draw K feature values each from uniform distribution over (-1.,1.) and arrange as design matrix "X".
-        // - For the coefficients of the generating distribution draw K values from surface of sphere S_(K-1)  and a bias from uniform(-0.5,0.5); arrange as DVector "coefs"
+        // - For each of the N samples (train/test) draw K feature values each from a uniform distribution over (-1.,1.) and arrange as design matrix "X".
+        // - For the coefficients of the generating distribution draw K values from surface of the unit sphere S_(K-1)  and a bias from uniform(-0.5,0.5); arrange as DVector "coefs"
         // - compute vector of probabilities(target=1) as sigmoid(X_ext * coefs)
         // - compute target values:for each sample i draw from Bernouilli(prob_i)
 
@@ -312,7 +312,7 @@ mod tests_logistic_regression {
 
         let N_train = 500; //Number of training samples
         let N_test = 80; //Number of test samples
-        let K = 5; //Number of Features
+        let K = 2; //Number of Features
 
         //generate random coefficients which will be used to generate target values for the x_i (direction uniform from sphere, bias uniform between -0.5 and 0.5 ) scaled by steepness
         let it_normal = rand::thread_rng().sample_iter(StandardNormal).take(K);
@@ -371,7 +371,10 @@ mod tests_logistic_regression {
                     "number of samples N_train={}, N_test={}, number of Features K={}",
                     N_train, N_test, K
                 );
-                println!("missclassification_rate: \t{}", missclassification_rate);
+                println!(
+                    "missclassification_rate(out of sample): \t{}",
+                    missclassification_rate
+                );
                 println!("Iterations: \t{}", output.iterations);
                 println!("Time taken: \t{:?}", elapsed_none);
                 // println!("Intercept: \t{:?}", output.intercept);


### PR DESCRIPTION
Hi! I looked into #56 and created an additional test for logistic_regression:
Features x_i and coefficients coefs are drawn randomly, probabilities for each sample to be in class 1 are computed according to p_i=sigmoid(x_i_extended*w) and the class labels are then drawn as y_i ~Bernoulli(p_i);

As far as I can tell your math does work.
For larger datasets the coef used for generation and the one computed from the data get similar.

I think the issue with the existing test case is the following: If the training data is linearly seperable, logistic regression isn't well defined (or at least there is no unique solution; many possible separating hyperplanes; This is often the case for very small sample size).
In that case the optimization wants the sigmoid become a step function which will lead to coefficients becoming verly large, (also eta_i={either very close to 1 or very close to 0} for all i;  so W goes to zero and its inverse goes to infinity on the diag).

side note: both coef and the "ones"-vector used in the calculation of W had the length n_row of X, that only works if model matrix(with additional 1s) is square.
