### PR TITLE
Fix warnings when running cargo doc

### DIFF
--- a/src/ml/regression/logistic.rs
+++ b/src/ml/regression/logistic.rs
@@ -44,10 +44,10 @@ pub struct LogisticRegressionOutput<T> {
 /// Algorithm to use for logistic regression.
 pub enum LogisticRegressionAlgorithm {
     /// Maximum Likelihood Estimation using Algorithmic Adjoint Differentiation
-    /// See: https://en.wikipedia.org/wiki/Logistic_regression#Maximum_likelihood_estimation_(MLE)
+    /// See: <https://en.wikipedia.org/wiki/Logistic_regression#Maximum_likelihood_estimation_(MLE)>
     MLE,
     /// Iterative Reweighted Least Squares
-    /// From Wikipedia (https://en.wikipedia.org/wiki/Logistic_regression#Iteratively_reweighted_least_squares_(IRLS)):
+    /// From Wikipedia (<https://en.wikipedia.org/wiki/Logistic_regression#Iteratively_reweighted_least_squares_(IRLS)>):
     /// """
     /// Binary logistic regression can, be calculated using
     /// iteratively reweighted least squares (IRLS), which is equivalent to

--- a/src/statistics/distributions/distribution.rs
+++ b/src/statistics/distributions/distribution.rs
@@ -48,32 +48,32 @@ pub trait Distribution {
 
     /// Returns the mean of the distribution.
     /// Mean is the average value of the distribution.
-    /// https://en.wikipedia.org/wiki/Mean
+    /// <https://en.wikipedia.org/wiki/Mean>
     fn mean(&self) -> f64;
 
     /// Returns the median of the distribution.
     /// Median is the value that splits the distribution into two equal parts.
-    /// https://en.wikipedia.org/wiki/Median
+    /// <https://en.wikipedia.org/wiki/Median>
     fn median(&self) -> f64;
 
     /// Returns the mode of the distribution.
     /// Mode is the value that maximizes the probability density function.
-    /// https://en.wikipedia.org/wiki/Mode_(statistics)
+    /// <https://en.wikipedia.org/wiki/Mode_(statistics)>
     fn mode(&self) -> f64;
 
     /// Returns the variance of the distribution.
     /// Variance is a measure of the spread of the distribution.
-    /// https://en.wikipedia.org/wiki/Variance
+    /// <https://en.wikipedia.org/wiki/Variance>
     fn variance(&self) -> f64;
 
     /// Returns the skewness of the distribution.
     /// Skewness is a measure of the asymmetry of the distribution.
-    /// https://en.wikipedia.org/wiki/Skewness
+    /// <https://en.wikipedia.org/wiki/Skewness>
     fn skewness(&self) -> f64;
 
     /// Returns the kurtosis of the distribution.
     /// Kurtosis is a measure of the "tailedness" of the distribution.
-    /// https://en.wikipedia.org/wiki/Kurtosis
+    /// <https://en.wikipedia.org/wiki/Kurtosis>
     fn kurtosis(&self) -> f64;
 
     /// Returns the entropy of the distribution.
@@ -82,7 +82,7 @@ pub trait Distribution {
 
     /// Moment generating function of the distribution.
     /// M = E[e^{tX}]
-    /// https://en.wikipedia.org/wiki/Moment-generating_function
+    /// <https://en.wikipedia.org/wiki/Moment-generating_function>
     fn mgf(&self, t: f64) -> f64;
 
     /// Generates a random sample from the distribution.

--- a/src/statistics/distributions/gaussian.rs
+++ b/src/statistics/distributions/gaussian.rs
@@ -16,7 +16,7 @@ use {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Gaussian (normal) distribution: X ~ N(mu, sigma^2)
-/// https://en.wikipedia.org/wiki/Normal_distribution
+/// <https://en.wikipedia.org/wiki/Normal_distribution>
 pub struct Gaussian {
     /// Mean (location).
     mean: f64,
@@ -228,11 +228,7 @@ mod tests_gaussian {
         assert_approx_equal!(normal.variance(), 1.0, 1e-8);
         assert_approx_equal!(normal.skewness(), 0.0, 1e-8);
         assert_approx_equal!(normal.kurtosis(), 0.0, 1e-8);
-        assert_approx_equal!(
-            normal.entropy(),
-            1.418_938_533_204_672_7,
-            1e-8
-        );
+        assert_approx_equal!(normal.entropy(), 1.418_938_533_204_672_7, 1e-8);
     }
 
     #[test]
@@ -248,10 +244,6 @@ mod tests_gaussian {
     fn test_gaussian_entropy() {
         let normal = Gaussian::default();
 
-        assert_approx_equal!(
-            normal.entropy(),
-            1.418_938_533_204_672_7,
-            1e-8
-        );
+        assert_approx_equal!(normal.entropy(), 1.418_938_533_204_672_7, 1e-8);
     }
 }

--- a/src/time/conventions.rs
+++ b/src/time/conventions.rs
@@ -6,7 +6,7 @@
 
 /// Date rolling business day conventions.
 ///
-/// From Wikipedia (https://en.wikipedia.org/wiki/Date_rolling):
+/// From Wikipedia (<https://en.wikipedia.org/wiki/Date_rolling>):
 /// """
 /// In finance, date rolling occurs when a payment day or date used to
 /// calculate accrued interest falls on a holiday, according to a given
@@ -41,14 +41,14 @@ pub enum BusinessDayConvention {
 
 /// Day count conventions.
 ///
-/// From Wikipedia (https://en.wikipedia.org/wiki/Day_count_convention):
+/// From Wikipedia (<https://en.wikipedia.org/wiki/Day_count_convention>):
 /// """
 /// In finance, a day count convention determines how interest accrues
 /// over time for a variety of investments, including bonds, notes,
 /// loans, mortgages, medium-term notes, swaps, and forward rate agreements (FRAs).
 /// This determines the number of days between two coupon payments,
 /// thus calculating the amount transferred on payment dates and also the
-/// accrued interest for dates between payments.[1] The day count is also
+/// accrued interest for dates between payments. The day count is also
 /// used to quantify periods of time when discounting a cash-flow to its
 /// present value. When a security such as a bond is sold between interest
 /// payment dates, the seller is eligible to some fraction of the coupon amount.

--- a/src/trading/order_book.rs
+++ b/src/trading/order_book.rs
@@ -13,7 +13,7 @@ use std::collections::VecDeque;
 /// The half-books are double-ended queues,
 /// one for the bids (buy orders) and one for the asks (sell orders).
 ///
-/// VecDeque<T> is not the most efficient choice, but it is convenient
+/// VecDeque\<T\> is not the most efficient choice, but it is convenient
 /// since we can push/pop from both the front and back easily.
 #[derive(Debug, Clone)]
 pub struct OrderBook {

--- a/src/trading/order_lifespan.rs
+++ b/src/trading/order_lifespan.rs
@@ -8,7 +8,7 @@ use std::fmt;
 
 /// Enum to indicate the lifespan of an order.
 ///
-/// See here: https://www.interactivebrokers.com/en/trading/ordertypes.php
+/// See here: <https://www.interactivebrokers.com/en/trading/ordertypes.php>
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OrderTimeInForce {
     /// """

--- a/src/trading/order_type.rs
+++ b/src/trading/order_type.rs
@@ -8,8 +8,8 @@ use std::fmt;
 
 /// Order type enum.
 /// Definitions from:   
-///     - https://www.interactivebrokers.com/en/trading/ordertypes.php
-///     - https://www.nasdaqtrader.com/content/productsservices/trading/ordertypesg.pdf
+///     - <https://www.interactivebrokers.com/en/trading/ordertypes.php>
+///     - <https://www.nasdaqtrader.com/content/productsservices/trading/ordertypesg.pdf>
 #[derive(Debug, Clone, Copy)]
 pub enum OrderType {
     /// """


### PR DESCRIPTION
Cargo doc was creating warnings. This MR cleans them up.