### PR TITLE
Add in additional and improved error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ serde_json = "1.0.96"       # https://docs.rs/serde_json/latest/serde_json
 statrs = "0.16.0"           # https://docs.rs/statrs/latest/statrs/
 time = "0.3.20"             # https://docs.rs/time/latest/time/
 yahoo_finance_api = "2.0.0" # https://docs.rs/yahoo-finance-api/latest/yahoo_finance_api/
+thiserror = "1.0.47"        # https://docs.rs/thiserror/latest/thiserror/
 
 ## Optional dependencies
 crossterm = { version = "0.27.0", optional = true } # https://docs.rs/crossterm/latest/crossterm/

--- a/src/data/io.rs
+++ b/src/data/io.rs
@@ -4,11 +4,12 @@
 // See LICENSE or <https://www.gnu.org/licenses/>.
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use polars::prelude::*;
-
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // STRUCTS, ENUMS, AND TRAITS
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+use polars::prelude::*;
+use thiserror::Error;
 
 /// Data struct.
 /// Contains data format, the file path to the data, and the data itself.
@@ -39,20 +40,20 @@ pub enum DataFormat {
 /// Eagerly reads data from the source.
 pub trait DataReader {
     /// Reads data from the source.
-    fn read(&mut self) -> Result<(), std::io::Error>;
+    fn read(&mut self) -> Result<(), DataError>;
 }
 
 /// Data writer trait.
 pub trait DataWriter {
     /// Writes data to the source.
-    fn write(&mut self) -> Result<(), std::io::Error>;
+    fn write(&mut self) -> Result<(), DataError>;
 }
 
 /// Data scanner trait.
 /// Lazily scans data from the source.
 pub trait DataScanner {
     /// Scans data from the source.
-    fn scan(&mut self) -> Result<LazyFrame, std::io::Error>;
+    fn scan(&mut self) -> Result<LazyFrame, DataError>;
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -71,25 +72,37 @@ impl Data {
     }
 }
 
+/// Catches errors from the [`Data`] struct that can come from [`std::io`] or [`polars`].
+#[derive(Debug, Error)]
+pub enum DataError {
+    /// Error variant arising from [`std::io`].
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Error variant arising from [`polars`].
+    #[error("Polars error: {0}")]
+    Polars(#[from] polars::prelude::PolarsError),
+}
+
 impl DataReader for Data {
-    fn read(&mut self) -> Result<(), std::io::Error> {
+    fn read(&mut self) -> Result<(), DataError> {
         match self.format {
             DataFormat::CSV => {
-                let df = CsvReader::from_path(&self.path).unwrap().finish().unwrap();
+                let df = CsvReader::from_path(&self.path)?.finish()?;
                 self.data = df;
 
                 Ok(())
             }
             DataFormat::JSON => {
-                let mut file = std::fs::File::open(&self.path).unwrap();
-                let df = JsonReader::new(&mut file).finish().unwrap();
+                let mut file = std::fs::File::open(&self.path)?;
+                let df = JsonReader::new(&mut file).finish()?;
                 self.data = df;
 
                 Ok(())
             }
             DataFormat::PARQUET => {
-                let mut file = std::fs::File::open(&self.path).unwrap();
-                let df = ParquetReader::new(&mut file).finish().unwrap();
+                let mut file = std::fs::File::open(&self.path)?;
+                let df = ParquetReader::new(&mut file).finish()?;
                 self.data = df;
 
                 Ok(())
@@ -99,31 +112,28 @@ impl DataReader for Data {
 }
 
 impl DataWriter for Data {
-    fn write(&mut self) -> Result<(), std::io::Error> {
+    fn write(&mut self) -> Result<(), DataError> {
         match self.format {
             DataFormat::CSV => {
-                let mut file = std::fs::File::create(&self.path).unwrap();
+                let mut file = std::fs::File::create(&self.path)?;
 
-                CsvWriter::new(&mut file).finish(&mut self.data).unwrap();
+                CsvWriter::new(&mut file).finish(&mut self.data)?;
 
                 Ok(())
             }
             DataFormat::JSON => {
-                let mut file = std::fs::File::create(&self.path).unwrap();
+                let mut file = std::fs::File::create(&self.path)?;
 
                 JsonWriter::new(&mut file)
                     .with_json_format(JsonFormat::Json)
-                    .finish(&mut self.data)
-                    .unwrap();
+                    .finish(&mut self.data)?;
 
                 Ok(())
             }
             DataFormat::PARQUET => {
-                let mut file = std::fs::File::create(&self.path).unwrap();
+                let mut file = std::fs::File::create(&self.path)?;
 
-                ParquetWriter::new(&mut file)
-                    .finish(&mut self.data)
-                    .unwrap();
+                ParquetWriter::new(&mut file).finish(&mut self.data)?;
 
                 Ok(())
             }
@@ -132,13 +142,14 @@ impl DataWriter for Data {
 }
 
 impl DataScanner for Data {
-    fn scan(&mut self) -> Result<LazyFrame, std::io::Error> {
+    fn scan(&mut self) -> Result<LazyFrame, DataError> {
         match self.format {
-            DataFormat::CSV => Ok(LazyCsvReader::new(&self.path).finish().unwrap()),
-            DataFormat::JSON => Ok(LazyJsonLineReader::new(self.path.clone()).finish().unwrap()),
-            DataFormat::PARQUET => {
-                Ok(LazyFrame::scan_parquet(&self.path, ScanArgsParquet::default()).unwrap())
-            }
+            DataFormat::CSV => Ok(LazyCsvReader::new(&self.path).finish()?),
+            DataFormat::JSON => Ok(LazyJsonLineReader::new(self.path.clone()).finish()?),
+            DataFormat::PARQUET => Ok(LazyFrame::scan_parquet(
+                &self.path,
+                ScanArgsParquet::default(),
+            )?),
         }
     }
 }
@@ -152,53 +163,59 @@ mod test_io {
     use super::*;
 
     #[test]
-    fn test_read_write_csv() {
+    fn test_read_write_csv() -> Result<(), DataError> {
         let mut data = Data {
             format: DataFormat::CSV,
             path: String::from("./src/data/examples/example.csv"),
             data: DataFrame::default(),
         };
 
-        data.read().unwrap();
+        data.read()?;
 
         data.path = String::from("./src/data/examples/write.csv");
 
-        data.write().unwrap();
+        data.write()?;
 
-        println!("{:?}", data.data)
+        println!("{:?}", data.data);
+
+        Ok(())
     }
 
     #[test]
-    fn test_read_write_json() {
+    fn test_read_write_json() -> Result<(), DataError> {
         let mut data = Data {
             format: DataFormat::JSON,
             path: String::from("./src/data/examples/example.json"),
             data: DataFrame::default(),
         };
 
-        data.read().unwrap();
+        data.read()?;
 
         data.path = String::from("./src/data/examples/write.json");
 
-        data.write().unwrap();
+        data.write()?;
 
-        println!("{:?}", data.data)
+        println!("{:?}", data.data);
+
+        Ok(())
     }
 
     #[test]
-    fn test_read_write_parquet() {
+    fn test_read_write_parquet() -> Result<(), DataError> {
         let mut data = Data {
             format: DataFormat::PARQUET,
             path: String::from("./src/data/examples/example.parquet"),
             data: DataFrame::default(),
         };
 
-        data.read().unwrap();
+        data.read()?;
 
         data.path = String::from("./src/data/examples/write.parquet");
 
-        data.write().unwrap();
+        data.write()?;
 
-        println!("{:?}", data.data)
+        println!("{:?}", data.data);
+
+        Ok(())
     }
 }


### PR DESCRIPTION
This PR will try to close #30.

Right now I have just started with adding `thiserror` to the `Cargo.toml`. The first module I added this in was in `io.rs`. 

Nice thing about `thiserror` is we can use it to envelop other errors with the derive macros `#[derive(Error)]` and `#[from]`. 

Take a look and see if you like this approach!