### PR TITLE
Add error handling to `statistics` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 14 September 2023
+- Added `Result` wrapping for `statistics` module.
+
 ## 29 August 2023
 
 - `plotting` mod deprecated, `plot_vector` is now a macro.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ serde_json = "1.0.96"       # https://docs.rs/serde_json/latest/serde_json
 statrs = "0.16.0"           # https://docs.rs/statrs/latest/statrs/
 time = "0.3.20"             # https://docs.rs/time/latest/time/
 yahoo_finance_api = "2.0.0" # https://docs.rs/yahoo-finance-api/latest/yahoo_finance_api/
+thiserror = "1.0.47"        # https://docs.rs/thiserror/latest/thiserror/
 
 ## Optional dependencies
 crossterm = { version = "0.27.0", optional = true } # https://docs.rs/crossterm/latest/crossterm/

--- a/src/data/io.rs
+++ b/src/data/io.rs
@@ -4,11 +4,12 @@
 // See LICENSE or <https://www.gnu.org/licenses/>.
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use polars::prelude::*;
-
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // STRUCTS, ENUMS, AND TRAITS
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+use polars::prelude::*;
+use thiserror::Error;
 
 /// Data struct.
 /// Contains data format, the file path to the data, and the data itself.
@@ -39,20 +40,20 @@ pub enum DataFormat {
 /// Eagerly reads data from the source.
 pub trait DataReader {
     /// Reads data from the source.
-    fn read(&mut self) -> Result<(), std::io::Error>;
+    fn read(&mut self) -> Result<(), DataError>;
 }
 
 /// Data writer trait.
 pub trait DataWriter {
     /// Writes data to the source.
-    fn write(&mut self) -> Result<(), std::io::Error>;
+    fn write(&mut self) -> Result<(), DataError>;
 }
 
 /// Data scanner trait.
 /// Lazily scans data from the source.
 pub trait DataScanner {
     /// Scans data from the source.
-    fn scan(&mut self) -> Result<LazyFrame, std::io::Error>;
+    fn scan(&mut self) -> Result<LazyFrame, DataError>;
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -71,25 +72,37 @@ impl Data {
     }
 }
 
+/// Catches errors from the [`Data`] struct that can come from [`std::io`] or [`polars`].
+#[derive(Debug, Error)]
+pub enum DataError {
+    /// Error variant arising from [`std::io`].
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Error variant arising from [`polars`].
+    #[error("Polars error: {0}")]
+    Polars(#[from] polars::prelude::PolarsError),
+}
+
 impl DataReader for Data {
-    fn read(&mut self) -> Result<(), std::io::Error> {
+    fn read(&mut self) -> Result<(), DataError> {
         match self.format {
             DataFormat::CSV => {
-                let df = CsvReader::from_path(&self.path).unwrap().finish().unwrap();
+                let df = CsvReader::from_path(&self.path)?.finish()?;
                 self.data = df;
 
                 Ok(())
             }
             DataFormat::JSON => {
-                let mut file = std::fs::File::open(&self.path).unwrap();
-                let df = JsonReader::new(&mut file).finish().unwrap();
+                let mut file = std::fs::File::open(&self.path)?;
+                let df = JsonReader::new(&mut file).finish()?;
                 self.data = df;
 
                 Ok(())
             }
             DataFormat::PARQUET => {
-                let mut file = std::fs::File::open(&self.path).unwrap();
-                let df = ParquetReader::new(&mut file).finish().unwrap();
+                let mut file = std::fs::File::open(&self.path)?;
+                let df = ParquetReader::new(&mut file).finish()?;
                 self.data = df;
 
                 Ok(())
@@ -99,31 +112,28 @@ impl DataReader for Data {
 }
 
 impl DataWriter for Data {
-    fn write(&mut self) -> Result<(), std::io::Error> {
+    fn write(&mut self) -> Result<(), DataError> {
         match self.format {
             DataFormat::CSV => {
-                let mut file = std::fs::File::create(&self.path).unwrap();
+                let mut file = std::fs::File::create(&self.path)?;
 
-                CsvWriter::new(&mut file).finish(&mut self.data).unwrap();
+                CsvWriter::new(&mut file).finish(&mut self.data)?;
 
                 Ok(())
             }
             DataFormat::JSON => {
-                let mut file = std::fs::File::create(&self.path).unwrap();
+                let mut file = std::fs::File::create(&self.path)?;
 
                 JsonWriter::new(&mut file)
                     .with_json_format(JsonFormat::Json)
-                    .finish(&mut self.data)
-                    .unwrap();
+                    .finish(&mut self.data)?;
 
                 Ok(())
             }
             DataFormat::PARQUET => {
-                let mut file = std::fs::File::create(&self.path).unwrap();
+                let mut file = std::fs::File::create(&self.path)?;
 
-                ParquetWriter::new(&mut file)
-                    .finish(&mut self.data)
-                    .unwrap();
+                ParquetWriter::new(&mut file).finish(&mut self.data)?;
 
                 Ok(())
             }
@@ -132,13 +142,14 @@ impl DataWriter for Data {
 }
 
 impl DataScanner for Data {
-    fn scan(&mut self) -> Result<LazyFrame, std::io::Error> {
+    fn scan(&mut self) -> Result<LazyFrame, DataError> {
         match self.format {
-            DataFormat::CSV => Ok(LazyCsvReader::new(&self.path).finish().unwrap()),
-            DataFormat::JSON => Ok(LazyJsonLineReader::new(self.path.clone()).finish().unwrap()),
-            DataFormat::PARQUET => {
-                Ok(LazyFrame::scan_parquet(&self.path, ScanArgsParquet::default()).unwrap())
-            }
+            DataFormat::CSV => Ok(LazyCsvReader::new(&self.path).finish()?),
+            DataFormat::JSON => Ok(LazyJsonLineReader::new(self.path.clone()).finish()?),
+            DataFormat::PARQUET => Ok(LazyFrame::scan_parquet(
+                &self.path,
+                ScanArgsParquet::default(),
+            )?),
         }
     }
 }
@@ -152,53 +163,59 @@ mod test_io {
     use super::*;
 
     #[test]
-    fn test_read_write_csv() {
+    fn test_read_write_csv() -> Result<(), DataError> {
         let mut data = Data {
             format: DataFormat::CSV,
             path: String::from("./src/data/examples/example.csv"),
             data: DataFrame::default(),
         };
 
-        data.read().unwrap();
+        data.read()?;
 
         data.path = String::from("./src/data/examples/write.csv");
 
-        data.write().unwrap();
+        data.write()?;
 
-        println!("{:?}", data.data)
+        println!("{:?}", data.data);
+
+        Ok(())
     }
 
     #[test]
-    fn test_read_write_json() {
+    fn test_read_write_json() -> Result<(), DataError> {
         let mut data = Data {
             format: DataFormat::JSON,
             path: String::from("./src/data/examples/example.json"),
             data: DataFrame::default(),
         };
 
-        data.read().unwrap();
+        data.read()?;
 
         data.path = String::from("./src/data/examples/write.json");
 
-        data.write().unwrap();
+        data.write()?;
 
-        println!("{:?}", data.data)
+        println!("{:?}", data.data);
+
+        Ok(())
     }
 
     #[test]
-    fn test_read_write_parquet() {
+    fn test_read_write_parquet() -> Result<(), DataError> {
         let mut data = Data {
             format: DataFormat::PARQUET,
             path: String::from("./src/data/examples/example.parquet"),
             data: DataFrame::default(),
         };
 
-        data.read().unwrap();
+        data.read()?;
 
         data.path = String::from("./src/data/examples/write.parquet");
 
-        data.write().unwrap();
+        data.write()?;
 
-        println!("{:?}", data.data)
+        println!("{:?}", data.data);
+
+        Ok(())
     }
 }

--- a/src/data/yahoo.rs
+++ b/src/data/yahoo.rs
@@ -7,8 +7,10 @@
 //! Module to fetch data from Yahoo! Finance,
 //! and store it in a Polars DataFrame object.
 
-use polars::prelude::*;
+use polars::{error::ErrString, prelude::*};
+use thiserror::Error;
 use time::OffsetDateTime;
+use yahoo::YahooError;
 use yahoo_finance_api as yahoo;
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -46,11 +48,11 @@ pub enum ReturnsType {
 /// Yahoo! Finance data reader trait.
 pub trait YahooFinanceReader {
     /// Retrieves the price history from Yahoo! Finance.
-    fn get_price_history(&mut self);
+    fn get_price_history(&mut self) -> Result<(), YahooFinanceError>;
     /// Retrieves the options chain from Yahoo! Finance.
-    fn get_options_chain(&mut self);
+    fn get_options_chain(&mut self) -> Result<(), YahooFinanceError>;
     /// Retrieves the latest quote from Yahoo! Finance.
-    fn get_latest_quote(&mut self);
+    fn get_latest_quote(&mut self) -> Result<(), YahooFinanceError>;
 }
 
 impl Default for YahooFinanceData {
@@ -65,6 +67,22 @@ impl Default for YahooFinanceData {
             latest_quote: None,
         }
     }
+}
+
+/// Yahoo! Finance data error enum that catches errors from the Yahoo! Finance API, Polars, and from potential missing inputs from users.
+#[derive(Debug, Error)]
+pub enum YahooFinanceError {
+    /// Error variant arising from the Yahoo! Finance API.
+    #[error("{0}")]
+    YahooError(#[from] YahooError),
+
+    /// Error variant arising from Polars.
+    #[error("{0}")]
+    PolarsError(#[from] polars::error::PolarsError),
+
+    /// Error variant arising from missing inputs.
+    #[error{"{0}"}]
+    MissingInput(String),
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -97,9 +115,9 @@ impl YahooFinanceData {
     }
 
     /// Computes the returns from the price history.
-    pub fn compute_returns(&mut self, returns_type: ReturnsType) {
+    pub fn compute_returns(&mut self, returns_type: ReturnsType) -> Result<(), YahooFinanceError> {
         if self.price_history.is_none() {
-            self.get_price_history()
+            self.get_price_history()?
         }
 
         // Closure to select all columns except for the date and volume columns.
@@ -112,7 +130,7 @@ impl YahooFinanceData {
                 self.returns = Some(
                     self.price_history
                         .clone()
-                        .unwrap()
+                        .ok_or(YahooError::EmptyDataSet)?
                         .lazy()
                         .select(vec![
                             col("date"),
@@ -120,23 +138,21 @@ impl YahooFinanceData {
                             (price_columns() / price_columns().shift(1) - lit(1.))
                                 .suffix("_arithmetic"),
                         ])
-                        .collect()
-                        .unwrap(),
+                        .collect()?,
                 );
             }
             ReturnsType::Absolute => {
                 self.returns = Some(
                     self.price_history
                         .clone()
-                        .unwrap()
+                        .ok_or(YahooError::EmptyDataSet)?
                         .lazy()
                         .select(vec![
                             col("date"),
                             col("volume"),
                             (price_columns() - price_columns().shift(1)).suffix("_absolute"),
                         ])
-                        .collect()
-                        .unwrap(),
+                        .collect()?,
                 );
             }
             ReturnsType::Logarithmic => {
@@ -148,12 +164,12 @@ impl YahooFinanceData {
                 // IF YOU SEE THIS, FEEL FREE TO SUBMIT A PULL REQUEST
                 // If you venture past here, you'll see more .unwrap()
                 // calls than you've ever seen before in your life.
-                let mut prices = self.price_history.clone().unwrap();
-                prices.apply("open", logarithm).unwrap();
-                prices.apply("high", logarithm).unwrap();
-                prices.apply("low", logarithm).unwrap();
-                prices.apply("close", logarithm).unwrap();
-                prices.apply("adjusted", logarithm).unwrap();
+                let mut prices = self.price_history.clone().ok_or(YahooError::EmptyDataSet)?;
+                prices.apply("open", logarithm)?;
+                prices.apply("high", logarithm)?;
+                prices.apply("low", logarithm)?;
+                prices.apply("close", logarithm)?;
+                prices.apply("adjusted", logarithm)?;
 
                 self.returns = Some(
                     prices
@@ -163,26 +179,27 @@ impl YahooFinanceData {
                             col("volume"),
                             (price_columns() - price_columns().shift(1)).suffix("_logarithmic"),
                         ])
-                        .collect()
-                        .unwrap(),
+                        .collect()?,
                 );
             }
         }
+        Ok(())
     }
 }
 
 impl YahooFinanceReader for YahooFinanceData {
-    fn get_price_history(&mut self) {
+    fn get_price_history(&mut self) -> Result<(), YahooFinanceError> {
         let provider = yahoo::YahooConnector::new();
 
         let response = tokio_test::block_on(provider.get_quote_history(
-            self.ticker.as_ref().unwrap(),
+            self.ticker.as_ref().ok_or(YahooFinanceError::MissingInput(
+                "No ticker provided.".to_string(),
+            ))?,
             self.start.unwrap_or(OffsetDateTime::UNIX_EPOCH),
             self.end.unwrap_or(OffsetDateTime::now_utc()),
-        ))
-        .unwrap();
+        ))?;
 
-        let quotes = response.quotes().unwrap();
+        let quotes = response.quotes()?;
 
         // The timestamp from Yahoo! Finance is in seconds since UNIX Epoch (1970-01-01).
         // So we need to divide by the number of seconds in a day (86,400s) to get the date,
@@ -199,7 +216,7 @@ impl YahooFinanceReader for YahooFinanceData {
         let adjclose = quotes.iter().map(|q| q.adjclose).collect::<Vec<_>>();
 
         let df = df!(
-            "date" => Series::new("date", date).cast(&DataType::Date).unwrap(),
+            "date" => Series::new("date", date).cast(&DataType::Date)?,
             "open" => open,
             "high" => high,
             "low" => low,
@@ -208,13 +225,16 @@ impl YahooFinanceReader for YahooFinanceData {
             "adjusted" => adjclose
         );
 
-        self.price_history = Some(df.unwrap());
+        self.price_history = Some(df?);
+
+        Ok(())
     }
 
-    fn get_options_chain(&mut self) {
+    fn get_options_chain(&mut self) -> Result<(), YahooFinanceError> {
         let provider = yahoo::YahooConnector::new();
-        let response =
-            tokio_test::block_on(provider.search_options(self.ticker.as_ref().unwrap())).unwrap();
+        let response = tokio_test::block_on(provider.search_options(self.ticker.as_ref().ok_or(
+            YahooFinanceError::MissingInput("No ticker provided.".to_string()),
+        )?))?;
 
         let options = response.options;
 
@@ -255,7 +275,7 @@ impl YahooFinanceReader for YahooFinanceData {
             "strike" => strike,
             "last_trade_date" => Series::new("last_trade_date", last_trade_date)
                 .cast(&DataType::Date)
-                .unwrap(),
+                ?,
             "last_price" => last_price,
             "bid" => bid,
             "ask" => ask,
@@ -264,17 +284,17 @@ impl YahooFinanceReader for YahooFinanceData {
             "volume" => volume,
             "open_interest" => open_interest,
             "impl_volatility" => impl_volatility
-            // "contract" => Series::new("date", date).cast(&DataType::Date).unwrap(),
+            // "contract" => Series::new("date", date).cast(&DataType::Date)?,
         );
 
-        self.options_chain = Some(df.unwrap());
+        self.options_chain = Some(df?);
 
         println!("{:?}", self.options_chain);
 
-        // println!("{:?}", response);
+        Ok(())
     }
 
-    fn get_latest_quote(&mut self) {
+    fn get_latest_quote(&mut self) -> Result<(), YahooFinanceError> {
         todo!()
     }
 }

--- a/src/ml/regression/logistic.rs
+++ b/src/ml/regression/logistic.rs
@@ -374,10 +374,10 @@ mod tests_logistic_regression {
         let distr_uniform_steepness = Uniform::new(0.5, 5., DistributionClass::Continuous);
 
         //generate random coefficients which will be used to generate target values for the x_i (direction uniform from sphere, bias uniform between -0.5 and 0.5 ) scaled by steepness
-        let bias = distr_uniform_bias.sample(1)[0];
-        let steepness = distr_uniform_steepness.sample(1)[0];
+        let bias = distr_uniform_bias.sample(1).unwrap()[0];
+        let steepness = distr_uniform_steepness.sample(1).unwrap()[0];
 
-        let coefs = DVector::from_vec(distr_normal.sample(K))
+        let coefs = DVector::from_vec(distr_normal.sample(K).unwrap())
             .normalize()
             .insert_row(0, bias)
             .scale(steepness);
@@ -390,17 +390,24 @@ mod tests_logistic_regression {
         //generate random design matrix for train/test
         let distr_uniform_features = Uniform::new(-0.5, 0.5, DistributionClass::Continuous);
 
-        let x_train =
-            DMatrix::<f64>::from_vec(N_train, K, distr_uniform_features.sample(N_train * K));
-        let x_test = DMatrix::from_vec(N_test, K, distr_uniform_features.sample(N_test * K));
+        let x_train = DMatrix::<f64>::from_vec(
+            N_train,
+            K,
+            distr_uniform_features.sample(N_train * K).unwrap(),
+        );
+        let x_test = DMatrix::from_vec(
+            N_test,
+            K,
+            distr_uniform_features.sample(N_test * K).unwrap(),
+        );
 
         //compute probabilities for each sample x_i
         let probs_train = logistic_regression.predict_proba(&x_train);
         let probs_test = logistic_regression.predict_proba(&x_test);
 
         // sample from Bernoulli distribution with p=p_i for each sample i
-        let y_train = probs_train.map(|p| Bernoulli::new(p).sample(1)[0]);
-        let y_test = probs_test.map(|p| Bernoulli::new(p).sample(1)[0]);
+        let y_train = probs_train.map(|p| Bernoulli::new(p).sample(1).unwrap()[0]);
+        let y_test = probs_test.map(|p| Bernoulli::new(p).sample(1).unwrap()[0]);
 
         // Fit the model to the training data.
         let input = LogisticRegressionInput {

--- a/src/statistics/distributions/bernoulli.rs
+++ b/src/statistics/distributions/bernoulli.rs
@@ -4,6 +4,8 @@
 // See LICENSE or <https://www.gnu.org/licenses/>.
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+use crate::statistics::DistributionError;
+
 use super::Distribution;
 use num_complex::Complex;
 
@@ -105,7 +107,7 @@ impl Distribution for Bernoulli {
         1.0 - self.p + self.p * f64::exp(t)
     }
 
-    fn sample(&self, n: usize) -> Vec<f64> {
+    fn sample(&self, n: usize) -> Result<Vec<f64>, DistributionError> {
         // IMPORT HERE TO AVOID CLASH WITH
         // `RustQuant::distributions::Distribution`
         use rand::thread_rng;
@@ -115,7 +117,7 @@ impl Distribution for Bernoulli {
 
         let mut rng = thread_rng();
 
-        let dist = Bernoulli::new(self.p).unwrap();
+        let dist = Bernoulli::new(self.p)?;
 
         let mut variates: Vec<f64> = Vec::with_capacity(n);
 
@@ -123,7 +125,7 @@ impl Distribution for Bernoulli {
             variates.push(dist.sample(&mut rng) as usize as f64);
         }
 
-        variates
+        Ok(variates)
     }
 }
 
@@ -273,16 +275,18 @@ mod tests_bernoulli {
     #[should_panic]
     fn test_sample_zero_size() {
         let bernoulli = Bernoulli::new(0.5);
-        bernoulli.sample(0);
+        _ = bernoulli.sample(0);
     }
 
     #[test]
-    fn test_sample_positive_size() {
+    fn test_sample_positive_size() -> Result<(), DistributionError> {
         let bernoulli = Bernoulli::new(0.5);
-        let sample = bernoulli.sample(100);
+        let sample = bernoulli.sample(100)?;
         assert_eq!(sample.len(), 100);
         for &value in sample.iter() {
             assert!(value == 0.0 || value == 1.0);
         }
+
+        Ok(())
     }
 }

--- a/src/statistics/distributions/binomial.rs
+++ b/src/statistics/distributions/binomial.rs
@@ -4,7 +4,7 @@
 // See LICENSE or <https://www.gnu.org/licenses/>.
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use crate::statistics::distributions::Distribution;
+use crate::statistics::{distributions::Distribution, DistributionError};
 use num_complex::Complex;
 use std::f64::consts::{E, PI};
 
@@ -107,7 +107,7 @@ impl Distribution for Binomial {
         ((1. - self.p) + self.p * t.exp()).powi(self.n as i32)
     }
 
-    fn sample(&self, n: usize) -> Vec<f64> {
+    fn sample(&self, n: usize) -> Result<Vec<f64>, DistributionError> {
         // IMPORT HERE TO AVOID CLASH WITH
         // `RustQuant::distributions::Distribution`
         use rand::thread_rng;
@@ -117,7 +117,7 @@ impl Distribution for Binomial {
 
         let mut rng = thread_rng();
 
-        let dist = Binomial::new(n as u64, self.p).unwrap();
+        let dist = Binomial::new(n as u64, self.p)?;
 
         let mut variates: Vec<f64> = Vec::with_capacity(n);
 
@@ -125,7 +125,7 @@ impl Distribution for Binomial {
             variates.push(dist.sample(&mut rng) as f64);
         }
 
-        variates
+        Ok(variates)
     }
 }
 

--- a/src/statistics/distributions/chi_squared.rs
+++ b/src/statistics/distributions/chi_squared.rs
@@ -4,7 +4,7 @@
 // See LICENSE or <https://www.gnu.org/licenses/>.
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use crate::statistics::distributions::Distribution;
+use crate::statistics::{distributions::Distribution, DistributionError};
 use num_complex::Complex;
 use statrs::function::gamma::{gamma, gamma_li};
 
@@ -98,7 +98,7 @@ impl Distribution for ChiSquared {
         (1.0 - 2.0 * t).powf(-(self.k as f64) / 2.0)
     }
 
-    fn sample(&self, n: usize) -> Vec<f64> {
+    fn sample(&self, n: usize) -> Result<Vec<f64>, DistributionError> {
         // IMPORT HERE TO AVOID CLASH WITH
         // `RustQuant::distributions::Distribution`
         use rand::thread_rng;
@@ -108,7 +108,7 @@ impl Distribution for ChiSquared {
 
         let mut rng = thread_rng();
 
-        let dist = ChiSquared::new(self.k as f64).unwrap();
+        let dist = ChiSquared::new(self.k as f64)?;
 
         let mut variates: Vec<f64> = Vec::with_capacity(n);
 
@@ -116,7 +116,7 @@ impl Distribution for ChiSquared {
             variates.push(dist.sample(&mut rng) as usize as f64);
         }
 
-        variates
+        Ok(variates)
     }
 }
 

--- a/src/statistics/distributions/distribution.rs
+++ b/src/statistics/distributions/distribution.rs
@@ -5,6 +5,7 @@
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 use num_complex::Complex;
+use thiserror::Error;
 
 /// Imaginary unit.
 #[allow(non_upper_case_globals)]
@@ -16,6 +17,38 @@ pub enum DistributionClass {
     Discrete,
     /// Continuous distribution.
     Continuous,
+}
+
+/// Distribution error type.
+#[derive(Debug, Error)]
+pub enum DistributionError {
+    /// Error variant from constructing Bernoulli distribution.
+    #[error("{0}")]
+    Bernoulli(#[from] rand_distr::BernoulliError),
+
+    /// Error variant from constructing Binomial distribution.
+    #[error("{0}")]
+    Binomial(#[from] rand_distr::BinomialError),
+
+    /// Error variant from constructing ChiSquared distribution.
+    #[error("{0}")]
+    ChiSquared(#[from] rand_distr::ChiSquaredError),
+
+    /// Error variant from constructing Exponential distribution.
+    #[error("{0}")]
+    Exponential(#[from] rand_distr::ExpError),
+
+    /// Error variant from constructing Gamma distribution.
+    #[error("{0}")]
+    Gamma(#[from] rand_distr::GammaError),
+
+    /// Error variant from constructing Gaussian distribution.
+    #[error("{0}")]
+    Gaussian(#[from] rand_distr::NormalError),
+
+    /// Error variant from constructing Poisson distribution.
+    #[error("{0}")]
+    Poisson(#[from] rand_distr::PoissonError),
 }
 
 /// Base trait for all distributions.
@@ -86,5 +119,5 @@ pub trait Distribution {
     fn mgf(&self, t: f64) -> f64;
 
     /// Generates a random sample from the distribution.
-    fn sample(&self, n: usize) -> Vec<f64>;
+    fn sample(&self, n: usize) -> Result<Vec<f64>, DistributionError>;
 }

--- a/src/statistics/distributions/exponential.rs
+++ b/src/statistics/distributions/exponential.rs
@@ -4,7 +4,7 @@
 // See LICENSE or <https://www.gnu.org/licenses/>.
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use crate::statistics::distributions::Distribution;
+use crate::statistics::{distributions::Distribution, DistributionError};
 use num_complex::Complex;
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -194,7 +194,7 @@ impl Distribution for Exponential {
         self.lambda * (self.lambda - t).recip()
     }
 
-    fn sample(&self, n: usize) -> Vec<f64> {
+    fn sample(&self, n: usize) -> Result<Vec<f64>, DistributionError> {
         // IMPORT HERE TO AVOID CLASH WITH
         // `RustQuant::distributions::Distribution`
         use rand::thread_rng;
@@ -203,14 +203,14 @@ impl Distribution for Exponential {
         assert!(n > 0);
 
         let mut rng = thread_rng();
-        let dist = Exp::new(self.lambda).unwrap();
+        let dist = Exp::new(self.lambda)?;
         let mut variates: Vec<f64> = Vec::with_capacity(n);
 
         for _ in 0..variates.capacity() {
             variates.push(dist.sample(&mut rng));
         }
 
-        variates
+        Ok(variates)
     }
 }
 

--- a/src/statistics/distributions/gamma.rs
+++ b/src/statistics/distributions/gamma.rs
@@ -4,7 +4,7 @@
 // See LICENSE or <https://www.gnu.org/licenses/>.
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use crate::statistics::distributions::Distribution;
+use crate::statistics::{distributions::Distribution, DistributionError};
 use num_complex::Complex;
 use statrs::function::gamma::{gamma, gamma_li};
 
@@ -115,7 +115,7 @@ impl Distribution for Gamma {
         (1.0 - t / self.beta).powf(-self.alpha)
     }
 
-    fn sample(&self, n: usize) -> Vec<f64> {
+    fn sample(&self, n: usize) -> Result<Vec<f64>, DistributionError> {
         // IMPORT HERE TO AVOID CLASH WITH
         // `RustQuant::distributions::Distribution`
         use rand::thread_rng;
@@ -125,7 +125,7 @@ impl Distribution for Gamma {
 
         let mut rng = thread_rng();
 
-        let dist = Gamma::new(self.alpha, self.beta.recip()).unwrap();
+        let dist = Gamma::new(self.alpha, self.beta.recip())?;
 
         let mut variates: Vec<f64> = Vec::with_capacity(n);
 
@@ -133,7 +133,7 @@ impl Distribution for Gamma {
             variates.push(dist.sample(&mut rng) as usize as f64);
         }
 
-        variates
+        Ok(variates)
     }
 }
 

--- a/src/statistics/distributions/gaussian.rs
+++ b/src/statistics/distributions/gaussian.rs
@@ -4,6 +4,8 @@
 // See LICENSE or <https://www.gnu.org/licenses/>.
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+use crate::statistics::DistributionError;
+
 use {
     super::Distribution,
     num_complex::Complex,
@@ -266,13 +268,13 @@ impl Distribution for Gaussian {
     ///
     /// let gaussian = Gaussian::new(0.0, 1.0);
     ///
-    /// let sample = gaussian.sample(1000);
+    /// let sample = gaussian.sample(1000).expect("Gaussian sampled");
     /// let mean = sample.iter().sum::<f64>() / sample.len() as f64;
     ///
     /// assert_approx_equal!(mean, gaussian.mean(), 0.1);
     /// ```
     ///
-    fn sample(&self, n: usize) -> Vec<f64> {
+    fn sample(&self, n: usize) -> Result<Vec<f64>, DistributionError> {
         // IMPORT HERE TO AVOID CLASH WITH
         // `RustQuant::distributions::Distribution`
         use rand::thread_rng;
@@ -281,14 +283,14 @@ impl Distribution for Gaussian {
         assert!(n > 0);
 
         let mut rng = thread_rng();
-        let normal = Normal::new(self.mean, self.variance.sqrt()).unwrap();
+        let normal = Normal::new(self.mean, self.variance.sqrt())?;
         let mut variates: Vec<f64> = Vec::with_capacity(n);
 
         for _ in 0..variates.capacity() {
             variates.push(normal.sample(&mut rng));
         }
 
-        variates
+        Ok(variates)
     }
 }
 
@@ -350,14 +352,16 @@ mod tests_gaussian {
     }
 
     #[test]
-    fn test_gaussian_variate_generator() {
+    fn test_gaussian_variate_generator() -> Result<(), DistributionError> {
         let normal = Gaussian::default();
 
-        let v = normal.sample(1000);
+        let v = normal.sample(1000)?;
 
         let mean = (v.iter().sum::<f64>()) / (v.len() as f64);
 
         assert_approx_equal!(mean, 0.0, 0.1);
+
+        Ok(())
     }
 
     #[test]

--- a/src/statistics/distributions/poisson.rs
+++ b/src/statistics/distributions/poisson.rs
@@ -4,7 +4,7 @@
 // See LICENSE or <https://www.gnu.org/licenses/>.
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use crate::statistics::distributions::Distribution;
+use crate::statistics::{distributions::Distribution, DistributionError};
 use num_complex::Complex;
 use statrs::function::gamma::*;
 
@@ -238,12 +238,12 @@ impl Distribution for Poisson {
     ///
     /// let poisson = Poisson::new(1.0);
     ///
-    /// let sample = poisson.sample(1000);
+    /// let sample = poisson.sample(1000).expect("Poisson sampled");
     /// let mean = sample.iter().sum::<f64>() / sample.len() as f64;
     ///
     /// assert_approx_equal!(mean, poisson.mean(), 0.1);
     /// ```
-    fn sample(&self, n: usize) -> Vec<f64> {
+    fn sample(&self, n: usize) -> Result<Vec<f64>, DistributionError> {
         // IMPORT HERE TO AVOID CLASH WITH
         // `RustQuant::distributions::Distribution`
         use rand::thread_rng;
@@ -253,7 +253,7 @@ impl Distribution for Poisson {
 
         let mut rng = thread_rng();
 
-        let dist = Poisson::new(self.lambda).unwrap();
+        let dist = Poisson::new(self.lambda)?;
 
         let mut variates: Vec<f64> = Vec::with_capacity(n);
 
@@ -261,7 +261,7 @@ impl Distribution for Poisson {
             variates.push(dist.sample(&mut rng) as usize as f64);
         }
 
-        variates
+        Ok(variates)
     }
 }
 
@@ -275,7 +275,7 @@ mod tests {
     use crate::assert_approx_equal;
 
     #[test]
-    fn test_poisson_distribution() {
+    fn test_poisson_distribution() -> Result<(), DistributionError> {
         let dist: Poisson = Poisson::new(1.0);
 
         // Characteristic function
@@ -325,8 +325,10 @@ mod tests {
         assert_approx_equal!(mgf, 5.5749415, 1e-7);
 
         // Sample
-        let sample = dist.sample(1000);
+        let sample = dist.sample(1000)?;
         let mean = sample.iter().sum::<f64>() / sample.len() as f64;
         assert_approx_equal!(mean, dist.mean(), 0.1);
+
+        Ok(())
     }
 }

--- a/src/statistics/distributions/uniform.rs
+++ b/src/statistics/distributions/uniform.rs
@@ -5,7 +5,7 @@
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 use super::DistributionClass;
-use crate::statistics::distributions::Distribution;
+use crate::statistics::{distributions::Distribution, DistributionError};
 use num_complex::Complex;
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -174,7 +174,7 @@ impl Distribution for Uniform {
         }
     }
 
-    fn sample(&self, n: usize) -> Vec<f64> {
+    fn sample(&self, n: usize) -> Result<Vec<f64>, DistributionError> {
         // IMPORT HERE TO AVOID CLASH WITH
         // `RustQuant::distributions::Distribution`
         use rand::thread_rng;
@@ -200,7 +200,7 @@ impl Distribution for Uniform {
             }
         }
 
-        variates
+        Ok(variates)
     }
 }
 


### PR DESCRIPTION
Have implemented `Result`s for `statistics/distributions` and left some other operations unchecked (e.g. in the `sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());` lines, as perhaps NaN operations should panic?).