### PR TITLE
Target `v0.1.0` rather than `v1.0.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 
 A Rust library for quantitative finance tools. Also the largest option pricing library in Rust.
 
-:dart: I want to hit a stable `v1.0.0` by the end of 2023, so any feedback, suggestions, or contributions are strongly welcomed!
+:dart: I want to hit a stable `v0.1.0` by the end of 2023, so any feedback, suggestions, or contributions are strongly welcomed!
 
 Email me at: <RustQuantContact@gmail.com>
 


### PR DESCRIPTION
I'd advise against going for a `1.0.0` release too early. It's generally not recommended to release a `1.0.0` until all the dependencies you publicly expose are at least `1.0.0`. This is why most of the rust ecosystem isn't `1.0.0` yet