### PR TITLE
fix: add macro feature flag for time dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ serde = "1.0.163"     # https://docs.rs/serde/latest/serde
 serde_json = "1.0.96" # https://docs.rs/serde_json/latest/serde_json
 statrs = "0.16.0"     # https://docs.rs/statrs/latest/statrs/
 thiserror = "1.0.47"  # https://docs.rs/thiserror/latest/thiserror/
-time = "0.3.20"       # https://docs.rs/time/latest/time/
+time = { version = "0.3.20", features = ["macros"] }       # https://docs.rs/time/latest/time/
 
 
 ## Optional dependencies


### PR DESCRIPTION
tests weren't working, adding macro feature flag for time dependency fixes it