### PR TITLE
fix warning in docs generation

### DIFF
--- a/src/curves/curve.rs
+++ b/src/curves/curve.rs
@@ -82,7 +82,7 @@ pub trait Curve {
     fn rate(&self, date: OffsetDateTime) -> f64;
 
     /// Returns the discount factor for the given date.
-    /// This is a convenience function that calls [rate] to get the rate for
+    /// This is a convenience function that calls [`rate`](Curve::rate) to get the rate for
     /// the given date, and then calculates the discount factor using the
     /// formula:
     /// $$
@@ -96,7 +96,7 @@ pub trait Curve {
     }
 
     /// Returns multiple discount factors for the given dates.
-    /// This is a convenience function that calls [discount_factor] for each
+    /// This is a convenience function that calls [`discount_factor`](Curve::discount_factor) for each
     /// date.
     fn discount_factors(&self, dates: &[OffsetDateTime]) -> Vec<f64> {
         dates

--- a/src/portfolio.rs
+++ b/src/portfolio.rs
@@ -8,8 +8,8 @@
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 //! A portfolio is a collection of [`Position`]s, which are simply a combination
-//! of an [`Instrument`](crate::instruments::Instrument), a quantity, a purchase price, and a current price.
-//! You may also specify the [`Currency`](crate::money::Currency) of the instrument.
+//! of an [`Instrument`], a quantity, a purchase price, and a current price.
+//! You may also specify the [`Currency`] of the instrument.
 //!
 //! # Example
 //!


### PR DESCRIPTION
Fixes warnings in docs generations:

1) Two links in docs in functions in the Curve trait were not correctly referenced, so I added references to the functions they were trying to reference.
2) Two links in `portfolio.rs` had redundant information when referencing other parts of the code causing errors in docs generation so they were removed.

After this I don't see any warning in docs generation when I build locally, and I the links go to the functions.