### PR TITLE
Turn on clippy::pedantic, and fix most errors.

### DIFF
--- a/src/autodiff/gradient.rs
+++ b/src/autodiff/gradient.rs
@@ -14,7 +14,7 @@
 // IMPORTS
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use crate::autodiff::*;
+use crate::autodiff::Variable;
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // GRADIENT TRAIT AND IMPLEMENTATIONS
@@ -79,6 +79,8 @@ impl<'v, const N: usize> Gradient<&[Variable<'v>; N], Vec<f64>> for Vec<f64> {
 mod test_gradient {
     use crate::{assert_approx_equal, autodiff::*};
 
+    use std::f64::EPSILON as EPS;
+
     #[test]
     fn test_borrowed_vector() {
         let g = Graph::new();
@@ -90,7 +92,7 @@ mod test_gradient {
 
         let grad = z.accumulate();
 
-        assert_approx_equal!(z.value, 2.0, 1e-15);
+        assert_approx_equal!(z.value, 2.0, EPS);
         assert_eq!(grad.wrt(&vec![x, y]), vec![2.0, 1.0]);
     }
 
@@ -104,7 +106,7 @@ mod test_gradient {
 
         let grad = z.accumulate();
 
-        assert_approx_equal!(z.value, 2.0, 1e-15);
+        assert_approx_equal!(z.value, 2.0, EPS);
         assert_eq!(grad.wrt(&v[..]), vec![2.0, 1.0]);
     }
 
@@ -119,7 +121,7 @@ mod test_gradient {
 
         let grad = z.accumulate();
 
-        assert_approx_equal!(z.value, 2.0, 1e-15);
+        assert_approx_equal!(z.value, 2.0, EPS);
         assert_eq!(grad.wrt([x, y]), vec![2.0, 1.0]);
     }
 
@@ -134,7 +136,7 @@ mod test_gradient {
 
         let grad = z.accumulate();
 
-        assert_approx_equal!(z.value, 2.0, 1e-15);
+        assert_approx_equal!(z.value, 2.0, EPS);
         assert_eq!(grad.wrt(&[x, y]), vec![2.0, 1.0]);
     }
 
@@ -149,9 +151,9 @@ mod test_gradient {
 
         let grad = z.accumulate();
 
-        assert_approx_equal!(z.value, 28979.885215, 1e-6);
-        assert_approx_equal!(grad.wrt(&x), y.value + x.value.cos(), 1e-15);
-        assert_approx_equal!(grad.wrt(&y), x.value, 1e-15);
+        assert_approx_equal!(z.value, 28_979.885_215_186_216, EPS);
+        assert_approx_equal!(grad.wrt(&x), y.value + x.value.cos(), EPS);
+        assert_approx_equal!(grad.wrt(&y), x.value, EPS);
     }
 
     #[test]
@@ -165,9 +167,9 @@ mod test_gradient {
 
         let grad = z.accumulate();
 
-        assert_approx_equal!(z.value, 3.5574077246549, 1e-14);
-        assert_approx_equal!(grad.wrt(&x), 5.425_518_820_814_76, 1e-15);
-        assert_approx_equal!(grad.wrt(&y), 1.0, 1e-15);
+        assert_approx_equal!(z.value, 3.557_407_724_654_902, EPS);
+        assert_approx_equal!(grad.wrt(&x), 5.425_518_820_814_759, EPS);
+        assert_approx_equal!(grad.wrt(&y), 1.0, EPS);
     }
 
     #[test]
@@ -183,9 +185,9 @@ mod test_gradient {
 
         println!("{}", grad.wrt(&x));
 
-        assert_approx_equal!(z.value, 3.762_195_691_083_631_4, 1e-10);
-        assert_approx_equal!(grad.wrt(&x), 7.253_720_815_694_037, 1e-10);
-        assert_approx_equal!(grad.wrt(&y), 3.62686040784701, 1e-10);
+        assert_approx_equal!(z.value, 3.762_195_691_083_631_4, EPS);
+        assert_approx_equal!(grad.wrt(&x), 7.253_720_815_694_037, EPS);
+        assert_approx_equal!(grad.wrt(&y), 3.626_860_407_847_018_6, EPS);
     }
 
     #[test]
@@ -199,9 +201,9 @@ mod test_gradient {
 
         let grad = z.accumulate();
 
-        assert_approx_equal!(z.value, 1.3620308304831552, 1e-8);
-        assert_approx_equal!(grad.wrt(&x), 1.874_990_751_363_869_7, 1e-15);
-        assert_approx_equal!(grad.wrt(&y), -0.099_819_345_045_613_27, 1e-15);
+        assert_approx_equal!(z.value, 1.362_030_830_483_155_2, EPS);
+        assert_approx_equal!(grad.wrt(&x), 1.874_990_751_363_869_3, EPS);
+        assert_approx_equal!(grad.wrt(&y), -0.099_819_345_045_613_52, EPS);
     }
 
     #[test]
@@ -221,8 +223,8 @@ mod test_gradient {
         println!("Grad wrt x = 1.0: \t{}", grad.wrt(&x));
         println!("Grad wrt y = 2.0: \t{}", grad.wrt(&y));
 
-        assert_approx_equal!(grad.wrt(&x), 0.140_971_808_425_461_7, 1e-15);
-        assert_approx_equal!(grad.wrt(&y), 1.506_614_888_597_196_4, 1e-15);
+        assert_approx_equal!(grad.wrt(&x), 0.140_971_808_425_461_7, EPS);
+        assert_approx_equal!(grad.wrt(&y), 1.506_614_888_597_196_4, EPS);
     }
 
     #[test]
@@ -236,9 +238,9 @@ mod test_gradient {
 
         let grad = z().accumulate();
 
-        assert_approx_equal!(z().value, 1.3620308304831552, 1e-8);
-        assert_approx_equal!(grad.wrt(&x), 1.874_990_751_363_869_7, 1e-15);
-        assert_approx_equal!(grad.wrt(&y), -0.099_819_345_045_613_27, 1e-15);
+        assert_approx_equal!(z().value, 1.362_030_830_483_155_2, 1e-8);
+        assert_approx_equal!(grad.wrt(&x), 1.874_990_751_363_869_3, EPS);
+        assert_approx_equal!(grad.wrt(&y), -0.099_819_345_045_613_52, EPS);
     }
 
     #[test]

--- a/src/autodiff/graph.rs
+++ b/src/autodiff/graph.rs
@@ -17,7 +17,7 @@
 // IMPORTS
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use crate::autodiff::*;
+use crate::autodiff::{Arity, Variable, Vertex};
 use std::cell::RefCell;
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -42,15 +42,17 @@ impl Default for Graph {
 /// Implementation for the `Graph` struct.
 impl Graph {
     /// Instantiate a new graph.
+    #[must_use]
     #[inline]
-    pub fn new() -> Self {
-        Graph {
+    pub const fn new() -> Self {
+        Self {
             vertices: RefCell::new(Vec::new()),
             // vertices: RefCell::new(Rc::new([])),
         }
     }
 
     /// Instantiate a new graph with a capacity.
+    #[must_use]
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
         Graph {
@@ -60,6 +62,7 @@ impl Graph {
     }
 
     /// Join two graphs together.
+    #[must_use]
     #[inline]
     pub fn join(&self, other: &Self) -> Self {
         let graph = self.clone();

--- a/src/autodiff/graphviz.rs
+++ b/src/autodiff/graphviz.rs
@@ -15,7 +15,7 @@
 //! language. At the moment, I'm simply trying to make a function that outputs
 //! `dot` code for a given graph.
 
-use crate::autodiff::*;
+use crate::autodiff::{Graph, Variable};
 
 // impl std::fmt::Display for Graph {
 //     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -80,6 +80,8 @@ pub fn graphviz(graph: &Graph, vars: &[Variable]) -> String {
 
 #[cfg(test)]
 mod test_graphviz {
+    use crate::autodiff::{Accumulate, Gradient, Powf};
+
     use super::*;
 
     // RUN THESE TESTS VIA: cargo t test_graphviz -- --nocapture

--- a/src/autodiff/overloading/add.rs
+++ b/src/autodiff/overloading/add.rs
@@ -136,6 +136,9 @@ impl<'v> Add<Variable<'v>> for f64 {
 mod test_overload {
     use crate::autodiff::{Accumulate, Gradient, Graph};
 
+    use crate::assert_approx_equal;
+    use std::f64::EPSILON as EPS;
+
     #[test]
     fn test_add() {
         // Variable + Variable
@@ -146,9 +149,9 @@ mod test_overload {
         let z = x + y;
         let grad = z.accumulate();
 
-        assert_eq!(z.value, 3.0);
-        assert_eq!(grad.wrt(&x), 1.0);
-        assert_eq!(grad.wrt(&y), 1.0);
+        assert_approx_equal!(z.value, 3.0, EPS);
+        assert_approx_equal!(grad.wrt(&x), 1.0, EPS);
+        assert_approx_equal!(grad.wrt(&y), 1.0, EPS);
 
         // Variable + f64
         let g = Graph::new();
@@ -158,8 +161,8 @@ mod test_overload {
         let z = x + y;
         let grad = z.accumulate();
 
-        assert_eq!(z.value, 3.0);
-        assert_eq!(grad.wrt(&x), 1.0);
+        assert_approx_equal!(z.value, 3.0, EPS);
+        assert_approx_equal!(grad.wrt(&x), 1.0, EPS);
 
         // f64 + Variable
         let g = Graph::new();
@@ -169,7 +172,7 @@ mod test_overload {
         let z = x + y;
         let grad = z.accumulate();
 
-        assert_eq!(z.value, 3.0);
-        assert_eq!(grad.wrt(&y), 1.0);
+        assert_approx_equal!(z.value, 3.0, EPS);
+        assert_approx_equal!(grad.wrt(&y), 1.0, EPS);
     }
 }

--- a/src/autodiff/overloading/div.rs
+++ b/src/autodiff/overloading/div.rs
@@ -15,7 +15,7 @@ use std::ops::{Div, DivAssign};
 /// d/dx x/y = 1/y
 /// d/dy x/y = -x/y^2
 
-/// DivAssign: Variable<'v> /= Variable<'v>
+/// `DivAssign`: Variable<'v> /= Variable<'v>
 impl<'v> DivAssign<Variable<'v>> for Variable<'v> {
     #[inline]
     fn div_assign(&mut self, other: Variable<'v>) {
@@ -25,7 +25,7 @@ impl<'v> DivAssign<Variable<'v>> for Variable<'v> {
     }
 }
 
-/// DivAssign: Variable<'v> /= f64
+/// `DivAssign`: Variable<'v> /= f64
 impl<'v> DivAssign<f64> for Variable<'v> {
     #[inline]
     fn div_assign(&mut self, other: f64) {
@@ -33,7 +33,7 @@ impl<'v> DivAssign<f64> for Variable<'v> {
     }
 }
 
-/// DivAssign: f64 /= Variable<'v>
+/// `DivAssign`: f64 /= Variable<'v>
 impl<'v> DivAssign<Variable<'v>> for f64 {
     #[inline]
     fn div_assign(&mut self, other: Variable<'v>) {
@@ -131,7 +131,9 @@ impl<'v> Div<Variable<'v>> for f64 {
 
 #[cfg(test)]
 mod test_overload {
+    use crate::assert_approx_equal;
     use crate::autodiff::{Accumulate, Gradient, Graph};
+    use std::f64::EPSILON as EPS;
 
     #[test]
     fn test_div() {
@@ -143,9 +145,9 @@ mod test_overload {
         let z = x / y;
         let grad = z.accumulate();
 
-        assert_eq!(z.value, 0.5);
-        assert_eq!(grad.wrt(&x), 0.5);
-        assert_eq!(grad.wrt(&y), -0.25);
+        assert_approx_equal!(z.value, 0.5, EPS);
+        assert_approx_equal!(grad.wrt(&x), 0.5, EPS);
+        assert_approx_equal!(grad.wrt(&y), -0.25, EPS);
 
         // Variable / f64
         let g = Graph::new();
@@ -155,8 +157,8 @@ mod test_overload {
         let z = x / y;
         let grad = z.accumulate();
 
-        assert_eq!(z.value, 0.5);
-        assert_eq!(grad.wrt(&x), 0.5);
+        assert_approx_equal!(z.value, 0.5, EPS);
+        assert_approx_equal!(grad.wrt(&x), 0.5, EPS);
 
         // f64 / Variable
         let g = Graph::new();
@@ -166,7 +168,7 @@ mod test_overload {
         let z = x / y;
         let grad = z.accumulate();
 
-        assert_eq!(z.value, 0.5);
-        assert_eq!(grad.wrt(&y), -0.25);
+        assert_approx_equal!(z.value, 0.5, EPS);
+        assert_approx_equal!(grad.wrt(&y), -0.25, EPS);
     }
 }

--- a/src/autodiff/overloading/f64.rs
+++ b/src/autodiff/overloading/f64.rs
@@ -48,6 +48,7 @@ impl<'v> Variable<'v> {
     /// assert!((z2.value - 1.0).abs() <= 1e-15);
     /// assert!((grad2.wrt(&x2) - (-1.0)).abs() <= 1e-15);
     /// ```
+    #[must_use]
     #[inline]
     pub fn abs(self) -> Self {
         Variable {
@@ -73,6 +74,7 @@ impl<'v> Variable<'v> {
     /// assert!((z1.value - 1.5707963267948966).abs() <= 1e-15);
     /// assert!((grad1.wrt(&x1) - (-1.0)).abs() <= 1e-15);
     /// ```
+    #[must_use]
     #[inline]
     pub fn acos(self) -> Self {
         Variable {
@@ -100,6 +102,7 @@ impl<'v> Variable<'v> {
     /// assert!((z.value - 2.2924316695611777).abs() <= 1e-15);
     /// assert!((grad.wrt(&x) - 0.20412414523193150818).abs() <= 1e-15);
     /// ```
+    #[must_use]
     #[inline]
     pub fn acosh(self) -> Self {
         Variable {
@@ -129,6 +132,7 @@ impl<'v> Variable<'v> {
     /// assert_eq!(z.value, 0.0);
     /// assert_eq!(grad.wrt(&x), 1.0);
     /// ```
+    #[must_use]
     #[inline]
     pub fn asin(self) -> Self {
         Variable {
@@ -161,6 +165,7 @@ impl<'v> Variable<'v> {
     /// assert_eq!(z.value, 0.0);
     /// assert_eq!(grad.wrt(&x), 1.0);
     /// ```
+    #[must_use]
     #[inline]
     pub fn asinh(self) -> Self {
         Variable {
@@ -189,6 +194,7 @@ impl<'v> Variable<'v> {
     /// assert_eq!(z.value, 0.0);
     /// assert_eq!(grad.wrt(&x), 1.0);
     /// ```
+    #[must_use]
     #[inline]
     pub fn atan(self) -> Self {
         Variable {
@@ -218,6 +224,7 @@ impl<'v> Variable<'v> {
     /// assert_approx_equal!(z.value,      0.00000000000, 1e-10);
     /// assert_approx_equal!(grad.wrt(&x), 1.00000000000, 1e-10);
     /// ```
+    #[must_use]
     #[inline]
     pub fn atanh(self) -> Self {
         Variable {
@@ -247,6 +254,7 @@ impl<'v> Variable<'v> {
     /// assert_approx_equal!(z.value,      1.00000000000, 1e-10);
     /// assert_approx_equal!(grad.wrt(&x), 0.33333333333, 1e-10);
     /// ```
+    #[must_use]
     #[inline]
     pub fn cbrt(self) -> Self {
         Variable {
@@ -276,6 +284,7 @@ impl<'v> Variable<'v> {
     /// assert_approx_equal!(z.value,       0.54030230586, 1e-10);
     /// assert_approx_equal!(grad.wrt(&x), -0.84147098480, 1e-10);
     /// ```
+    #[must_use]
     #[inline]
     pub fn cos(self) -> Self {
         Variable {
@@ -304,6 +313,7 @@ impl<'v> Variable<'v> {
     /// assert_approx_equal!(z.value,      1.54308063481, 1e-10);
     /// assert_approx_equal!(grad.wrt(&x), 1.17520119364, 1e-10);
     /// ```
+    #[must_use]
     #[inline]
     pub fn cosh(self) -> Self {
         Variable {
@@ -330,6 +340,7 @@ impl<'v> Variable<'v> {
     /// assert_eq!(z.value, std::f64::consts::E);
     /// assert_eq!(grad.wrt(&x), std::f64::consts::E);
     /// ```
+    #[must_use]
     #[inline]
     pub fn exp(self) -> Self {
         Variable {
@@ -357,6 +368,7 @@ impl<'v> Variable<'v> {
     /// assert_approx_equal!(z.value,      2.00000000000, 1e-10);
     /// assert_approx_equal!(grad.wrt(&x), 1.38629436111, 1e-10);
     /// ```
+    #[must_use]
     #[inline]
     pub fn exp2(self) -> Self {
         Variable {
@@ -386,6 +398,7 @@ impl<'v> Variable<'v> {
     /// assert_approx_equal!(z.value,      1.71828182845, 1e-10);
     /// assert_approx_equal!(grad.wrt(&x), 2.71828182845, 1e-10);
     /// ```
+    #[must_use]
     #[inline]
     pub fn exp_m1(self) -> Self {
         Variable {
@@ -413,6 +426,7 @@ impl<'v> Variable<'v> {
     /// assert_eq!(z.value, 1.0);
     /// assert_eq!(grad.wrt(&x), 0.36787944117144233);
     /// ```
+    #[must_use]
     #[inline]
     pub fn ln(self) -> Self {
         Variable {
@@ -440,6 +454,7 @@ impl<'v> Variable<'v> {
     /// assert_approx_equal!(z.value,      0.69314718055, 1e-10);
     /// assert_approx_equal!(grad.wrt(&x), 0.50000000000, 1e-10);
     /// ```
+    #[must_use]
     #[inline]
     pub fn ln_1p(self) -> Self {
         Variable {
@@ -467,6 +482,7 @@ impl<'v> Variable<'v> {
     /// assert_approx_equal!(z.value,      0.00000000000, 1e-10);
     /// assert_approx_equal!(grad.wrt(&x), 1.00000000000, 1e-10);
     /// ```
+    #[must_use]
     #[inline]
     pub fn log10(self) -> Self {
         Variable {
@@ -494,6 +510,7 @@ impl<'v> Variable<'v> {
     /// assert_approx_equal!(z.value,      0.00000000000, 1e-10);
     /// assert_approx_equal!(grad.wrt(&x), 1.00000000000, 1e-10);
     /// ```
+    #[must_use]
     #[inline]
     pub fn log2(self) -> Self {
         Variable {
@@ -532,6 +549,7 @@ impl<'v> Variable<'v> {
     /// assert_eq!(z.value, 1.0);
     /// assert_eq!(grad.wrt(&x), -1.0);
     /// ```
+    #[must_use]
     #[inline]
     pub fn recip(self) -> Self {
         Variable {
@@ -561,6 +579,7 @@ impl<'v> Variable<'v> {
     /// assert_approx_equal!(z.value,      0.84147098480, 1e-10);
     /// assert_approx_equal!(grad.wrt(&x), 0.54030230586, 1e-10);
     /// ```
+    #[must_use]
     #[inline]
     pub fn sin(self) -> Self {
         Variable {
@@ -588,6 +607,7 @@ impl<'v> Variable<'v> {
     /// assert_approx_equal!(z.value,      1.17520119364, 1e-10);
     /// assert_approx_equal!(grad.wrt(&x), 1.54308063481, 1e-10);
     /// ```
+    #[must_use]
     #[inline]
     pub fn sinh(self) -> Self {
         Variable {
@@ -614,6 +634,7 @@ impl<'v> Variable<'v> {
     /// assert_eq!(z.value, std::f64::consts::SQRT_2);
     /// assert_eq!(grad.wrt(&x), 1.0 / (2.0 * std::f64::consts::SQRT_2));
     /// ```
+    #[must_use]
     #[inline]
     pub fn sqrt(self) -> Self {
         Variable {
@@ -643,6 +664,7 @@ impl<'v> Variable<'v> {
     /// assert_approx_equal!(z.value,      1.55740772465, 1e-10);
     /// assert_approx_equal!(grad.wrt(&x), 3.42551882081, 1e-10);
     /// ```
+    #[must_use]
     #[inline]
     pub fn tan(self) -> Self {
         Variable {
@@ -672,6 +694,7 @@ impl<'v> Variable<'v> {
     /// assert_approx_equal!(z.value,      0.7615941559, 1e-10);
     /// assert_approx_equal!(grad.wrt(&x), 0.4199743416, 1e-10);
     /// ```
+    #[must_use]
     #[inline]
     pub fn tanh(self) -> Self {
         Variable {
@@ -694,6 +717,7 @@ impl<'v> Variable<'v> {
 mod test_overloading_f64 {
     use crate::assert_approx_equal;
     use crate::autodiff::*;
+    use std::f64::EPSILON as EPS;
 
     #[test]
     fn test_values() {
@@ -702,30 +726,30 @@ mod test_overloading_f64 {
         let x = g.var(1.0);
 
         // VALUES
-        assert_approx_equal!((-x).value, -1.0, 1e-10);
-        assert_approx_equal!(x.log2().value, 0.0, 1e-10);
-        assert_approx_equal!(x.exp2().value, 2.0, 1e-10);
-        assert_approx_equal!(x.exp_m1().value, 1.718281828459045, 1e-10);
-        assert_approx_equal!(x.ln().value, 0.0, 1e-10);
-        assert_approx_equal!(x.ln_1p().value, std::f64::consts::LN_2, 1e-10);
-        assert_approx_equal!(x.log10().value, 0.0, 1e-10);
-        assert_approx_equal!(x.log2().value, 0.0, 1e-10);
-        assert_approx_equal!(x.recip().value, 1.0, 1e-10);
-        assert_approx_equal!(x.sqrt().value, 1.0, 1e-10);
-        assert_approx_equal!(x.cbrt().value, 1.0, 1e-10);
-        assert_approx_equal!(x.sin().value, 0.8414709848078965, 1e-10);
-        assert_approx_equal!(x.cos().value, 0.5403023058681398, 1e-10);
-        assert_approx_equal!(x.tan().value, 1.5574077246549023, 1e-10);
-        assert_approx_equal!(x.asin().value, std::f64::consts::FRAC_PI_2, 1e-10);
-        assert_approx_equal!(x.acos().value, 0.0, 1e-10);
-        assert_approx_equal!(x.atan().value, std::f64::consts::FRAC_PI_4, 1e-10);
-        assert_approx_equal!(x.sinh().value, 1.1752011936438014, 1e-10);
-        assert_approx_equal!(x.cosh().value, 1.5430806348152437, 1e-10);
-        assert_approx_equal!(x.tanh().value, 0.7615941559557649, 1e-10);
-        assert_approx_equal!(x.asinh().value, 0.881373587019543, 1e-10);
-        assert_approx_equal!(x.acosh().value, 0.0, 1e-10);
-        assert_eq!(x.atanh().value, std::f64::INFINITY);
-        assert_approx_equal!(x.abs().value, 1.0, 1e-10);
+        assert_approx_equal!((-x).value, -1.0, EPS);
+        assert_approx_equal!(x.log2().value, 0.0, EPS);
+        assert_approx_equal!(x.exp2().value, 2.0, EPS);
+        assert_approx_equal!(x.exp_m1().value, 1.718_281_828_459_045, EPS);
+        assert_approx_equal!(x.ln().value, 0.0, EPS);
+        assert_approx_equal!(x.ln_1p().value, std::f64::consts::LN_2, EPS);
+        assert_approx_equal!(x.log10().value, 0.0, EPS);
+        assert_approx_equal!(x.log2().value, 0.0, EPS);
+        assert_approx_equal!(x.recip().value, 1.0, EPS);
+        assert_approx_equal!(x.sqrt().value, 1.0, EPS);
+        assert_approx_equal!(x.cbrt().value, 1.0, EPS);
+        assert_approx_equal!(x.sin().value, 0.841_470_984_807_896_5, EPS);
+        assert_approx_equal!(x.cos().value, 0.540_302_305_868_139_8, EPS);
+        assert_approx_equal!(x.tan().value, 1.557_407_724_654_902_3, EPS);
+        assert_approx_equal!(x.asin().value, std::f64::consts::FRAC_PI_2, EPS);
+        assert_approx_equal!(x.acos().value, 0.0, EPS);
+        assert_approx_equal!(x.atan().value, std::f64::consts::FRAC_PI_4, EPS);
+        assert_approx_equal!(x.sinh().value, 1.175_201_193_643_801_4, EPS);
+        assert_approx_equal!(x.cosh().value, 1.543_080_634_815_243_7, EPS);
+        assert_approx_equal!(x.tanh().value, 0.761_594_155_955_764_9, EPS);
+        assert_approx_equal!(x.asinh().value, 0.881_373_587_019_543, EPS);
+        assert_approx_equal!(x.acosh().value, 0.0, EPS);
+        assert!(x.atanh().is_infinite() && x.atanh().is_positive());
+        assert_approx_equal!(x.abs().value, 1.0, EPS);
     }
 
     #[test]
@@ -735,26 +759,27 @@ mod test_overloading_f64 {
         let x = g.var(1.0);
 
         // GRADIENTS
-        assert_approx_equal!((-x).accumulate().wrt(&x), -1.0, 1e-10);
-        assert_approx_equal!(x.log2().accumulate().wrt(&x), 1.0, 1e-10);
-        assert_approx_equal!(x.exp2().accumulate().wrt(&x), 1.3862943611198906, 1e-10);
-        assert_approx_equal!(x.exp_m1().accumulate().wrt(&x), std::f64::consts::E, 1e-10);
-        assert_approx_equal!(x.ln().accumulate().wrt(&x), 1.0, 1e-10);
-        assert_approx_equal!(x.ln_1p().accumulate().wrt(&x), 0.5, 1e-10);
-        assert_approx_equal!(x.log10().accumulate().wrt(&x), 1.0, 1e-10);
-        assert_approx_equal!(x.log2().accumulate().wrt(&x), 1.0, 1e-10);
-        assert_approx_equal!(x.recip().accumulate().wrt(&x), -1.0, 1e-10);
-        assert_approx_equal!(x.sqrt().accumulate().wrt(&x), 0.5, 1e-10);
-        assert_approx_equal!(x.cbrt().accumulate().wrt(&x), 0.3333333333333333, 1e-10);
-        assert_approx_equal!(x.sin().accumulate().wrt(&x), 0.5403023058681398, 1e-10);
-        assert_approx_equal!(x.cos().accumulate().wrt(&x), -0.8414709848078965, 1e-10);
-        assert_approx_equal!(x.tan().accumulate().wrt(&x), 3.4255188208149777, 1e-10);
-        assert_approx_equal!(x.sinh().accumulate().wrt(&x), 1.5430806348152437, 1e-10);
-        assert_approx_equal!(x.atan().accumulate().wrt(&x), 0.5, 1e-10);
-        assert_approx_equal!(x.cosh().accumulate().wrt(&x), 1.1752011936438014, 1e-10);
-        assert_approx_equal!(x.tanh().accumulate().wrt(&x), 0.41997434161402614, 1e-10);
-        assert_approx_equal!(x.asinh().accumulate().wrt(&x), 1.0 / 2_f64.sqrt(), 1e-10);
-        assert_approx_equal!(x.abs().accumulate().wrt(&x), 1.0, 1e-10);
+        assert_approx_equal!((-x).accumulate().wrt(&x), -1.0, EPS);
+        assert_approx_equal!(x.log2().accumulate().wrt(&x), 1.0, EPS);
+        assert_approx_equal!(x.exp2().accumulate().wrt(&x), 1.386_294_361_119_890_6, EPS);
+        assert_approx_equal!(x.exp_m1().accumulate().wrt(&x), std::f64::consts::E, EPS);
+        assert_approx_equal!(x.ln().accumulate().wrt(&x), 1.0, EPS);
+        assert_approx_equal!(x.ln().accumulate().wrt(&x), 1.0, EPS);
+        assert_approx_equal!(x.ln_1p().accumulate().wrt(&x), 0.5, EPS);
+        assert_approx_equal!(x.log10().accumulate().wrt(&x), 1.0, EPS);
+        assert_approx_equal!(x.log2().accumulate().wrt(&x), 1.0, EPS);
+        assert_approx_equal!(x.recip().accumulate().wrt(&x), -1.0, EPS);
+        assert_approx_equal!(x.sqrt().accumulate().wrt(&x), 0.5, EPS);
+        assert_approx_equal!(x.cbrt().accumulate().wrt(&x), 0.333_333_333_333_333_3, EPS);
+        assert_approx_equal!(x.sin().accumulate().wrt(&x), 0.540_302_305_868_139_8, EPS);
+        assert_approx_equal!(x.cos().accumulate().wrt(&x), -0.841_470_984_807_896_5, EPS);
+        assert_approx_equal!(x.tan().accumulate().wrt(&x), 3.425_518_820_814_759, EPS);
+        assert_approx_equal!(x.sinh().accumulate().wrt(&x), 1.543_080_634_815_243_7, EPS);
+        assert_approx_equal!(x.atan().accumulate().wrt(&x), 0.5, EPS);
+        assert_approx_equal!(x.cosh().accumulate().wrt(&x), 1.175_201_193_643_801_4, EPS);
+        assert_approx_equal!(x.tanh().accumulate().wrt(&x), 0.419_974_341_614_026_14, EPS);
+        assert_approx_equal!(x.asinh().accumulate().wrt(&x), 1.0 / 2_f64.sqrt(), EPS);
+        assert_approx_equal!(x.abs().accumulate().wrt(&x), 1.0, EPS);
         assert!(x.atanh().accumulate().wrt(&x).is_nan());
         assert!(x.acosh().accumulate().wrt(&x).is_nan());
         assert!(x.asin().accumulate().wrt(&x).is_nan());

--- a/src/autodiff/overloading/iter.rs
+++ b/src/autodiff/overloading/iter.rs
@@ -71,18 +71,20 @@ impl<'v> Product<Variable<'v>> for Variable<'v> {
 
 #[cfg(test)]
 mod test_overload {
+    use crate::assert_approx_equal;
     use crate::autodiff::{Accumulate, Gradient, Graph, Variable};
+    use std::f64::EPSILON as EPS;
 
     #[test]
     fn test_sum() {
         let g = Graph::new();
 
-        let params = (0..100).map(|x| g.var(x as f64)).collect::<Vec<_>>();
+        let params = (0..100).map(|x| g.var(f64::from(x))).collect::<Vec<_>>();
         let sum = params.iter().copied().sum::<Variable>();
         let derivs = sum.accumulate();
 
         for i in derivs.wrt(&params) {
-            assert_eq!(i, 1.0);
+            assert_approx_equal!(i, 1.0, EPS);
         }
     }
 
@@ -90,7 +92,7 @@ mod test_overload {
     fn test_product() {
         let g = Graph::new();
 
-        let params = (1..=5).map(|x| g.var(x as f64)).collect::<Vec<_>>();
+        let params = (1..=5).map(|x| g.var(f64::from(x))).collect::<Vec<_>>();
         let prod = params.iter().copied().product::<Variable>();
 
         let derivs = prod.accumulate();
@@ -102,7 +104,7 @@ mod test_overload {
         assert_eq!(n, m);
 
         for (&expect, &gradient) in expects.iter().zip(true_gradient.iter()) {
-            assert_eq!(expect, gradient);
+            assert_approx_equal!(expect, gradient, EPS);
         }
     }
 }

--- a/src/autodiff/overloading/minmax.rs
+++ b/src/autodiff/overloading/minmax.rs
@@ -159,7 +159,10 @@ impl<'v> Max<Variable<'v>> for f64 {
 
 #[cfg(test)]
 mod test_overloading_minmax {
+    use crate::assert_approx_equal;
     use crate::autodiff::*;
+
+    use std::f64::EPSILON as EPS;
 
     #[test]
     fn test_values() {
@@ -186,15 +189,15 @@ mod test_overloading_minmax {
         let y = g.var(2.0);
 
         // GRADIENTS
-        assert!(Min::min(&x, y).accumulate().wrt(&x) == 1.0);
-        assert!(Min::min(&x, y).accumulate().wrt(&y) == 0.0);
-        assert!(Max::max(&x, y).accumulate().wrt(&x) == 0.0);
-        assert!(Max::max(&x, y).accumulate().wrt(&y) == 1.0);
+        assert_approx_equal!(Min::min(&x, y).accumulate().wrt(&x), 1.0, EPS);
+        assert_approx_equal!(Min::min(&x, y).accumulate().wrt(&y), 0.0, EPS);
+        assert_approx_equal!(Max::max(&x, y).accumulate().wrt(&x), 0.0, EPS);
+        assert_approx_equal!(Max::max(&x, y).accumulate().wrt(&y), 1.0, EPS);
 
-        assert!(Min::min(&x, 2_f64).accumulate().wrt(&x) == 1.0);
-        assert!(Max::max(&x, 2_f64).accumulate().wrt(&x) == 0.0);
+        assert_approx_equal!(Min::min(&x, 2_f64).accumulate().wrt(&x), 1.0, EPS);
+        assert_approx_equal!(Max::max(&x, 2_f64).accumulate().wrt(&x), 0.0, EPS);
 
-        assert!(Min::min(&2_f64, x).accumulate().wrt(&x) == 0.0);
-        assert!(Max::max(&2_f64, x).accumulate().wrt(&x) == 1.0);
+        assert_approx_equal!(Min::min(&2_f64, x).accumulate().wrt(&x), 0.0, EPS);
+        assert_approx_equal!(Max::max(&2_f64, x).accumulate().wrt(&x), 1.0, EPS);
     }
 }

--- a/src/autodiff/overloading/mul.rs
+++ b/src/autodiff/overloading/mul.rs
@@ -136,7 +136,9 @@ impl<'v> Mul<Variable<'v>> for f64 {
 
 #[cfg(test)]
 mod test_overload {
+    use crate::assert_approx_equal;
     use crate::autodiff::{Accumulate, Gradient, Graph};
+    use std::f64::EPSILON as EPS;
 
     #[test]
     fn test_mul() {
@@ -148,9 +150,9 @@ mod test_overload {
         let z = x * y;
         let grad = z.accumulate();
 
-        assert_eq!(z.value, 2.0);
-        assert_eq!(grad.wrt(&x), 2.0);
-        assert_eq!(grad.wrt(&y), 1.0);
+        assert_approx_equal!(z.value, 2.0, EPS);
+        assert_approx_equal!(grad.wrt(&x), 2.0, EPS);
+        assert_approx_equal!(grad.wrt(&y), 1.0, EPS);
 
         // Variable * f64
         let g = Graph::new();
@@ -160,8 +162,8 @@ mod test_overload {
         let z = x * y;
         let grad = z.accumulate();
 
-        assert_eq!(z.value, 2.0);
-        assert_eq!(grad.wrt(&x), 2.0);
+        assert_approx_equal!(z.value, 2.0, EPS);
+        assert_approx_equal!(grad.wrt(&x), 2.0, EPS);
 
         // f64 * Variable
         let g = Graph::new();
@@ -171,7 +173,7 @@ mod test_overload {
         let z = x * y;
         let grad = z.accumulate();
 
-        assert_eq!(z.value, 2.0);
-        assert_eq!(grad.wrt(&y), 1.0);
+        assert_approx_equal!(z.value, 2.0, EPS);
+        assert_approx_equal!(grad.wrt(&y), 1.0, EPS);
     }
 }

--- a/src/autodiff/overloading/pow.rs
+++ b/src/autodiff/overloading/pow.rs
@@ -124,7 +124,7 @@ impl<'v> Powi<i32> for Variable<'v> {
             index: self.graph.push(
                 Arity::Binary,
                 &[self.index, self.index],
-                &[n as f64 * f64::powi(self.value, n - 1), 0.0],
+                &[f64::from(n) * f64::powi(self.value, n - 1), 0.0],
             ),
         }
     }

--- a/src/autodiff/overloading/statrs.rs
+++ b/src/autodiff/overloading/statrs.rs
@@ -30,6 +30,7 @@ impl<'v> Variable<'v> {
     /// assert_approx_equal!(z.value,      0.84270079294, 1e-10);
     /// assert_approx_equal!(grad.wrt(&x), 0.41510749742, 1e-10);
     /// ```
+    #[must_use]
     #[inline]
     pub fn erf(self) -> Self {
         use statrs::function::erf::erf;
@@ -61,6 +62,7 @@ impl<'v> Variable<'v> {
     /// assert_approx_equal!(z.value,       0.15729920705, 1e-10);
     /// assert_approx_equal!(grad.wrt(&x), -0.41510749742, 1e-10);
     /// ```
+    #[must_use]
     #[inline]
     pub fn erfc(self) -> Self {
         use statrs::function::erf::erfc;

--- a/src/autodiff/overloading/sub.rs
+++ b/src/autodiff/overloading/sub.rs
@@ -15,7 +15,7 @@ use std::ops::{Add, Neg, Sub, SubAssign};
 /// d/dx x - y = 1
 /// d/dy x - y = -1
 
-/// SubAssign: Variable<'v> -= Variable<'v>
+/// `SubAssign`: Variable<'v> -= Variable<'v>
 impl<'v> SubAssign<Variable<'v>> for Variable<'v> {
     #[inline]
     fn sub_assign(&mut self, other: Variable<'v>) {
@@ -25,7 +25,7 @@ impl<'v> SubAssign<Variable<'v>> for Variable<'v> {
     }
 }
 
-/// SubAssign: Variable<'v> -= f64
+/// `SubAssign`: Variable<'v> -= f64
 impl<'v> SubAssign<f64> for Variable<'v> {
     #[inline]
     fn sub_assign(&mut self, other: f64) {
@@ -33,7 +33,7 @@ impl<'v> SubAssign<f64> for Variable<'v> {
     }
 }
 
-/// SubAssign: f64 -= Variable<'v>
+/// `SubAssign`: f64 -= Variable<'v>
 impl<'v> SubAssign<Variable<'v>> for f64 {
     #[inline]
     fn sub_assign(&mut self, other: Variable<'v>) {
@@ -140,9 +140,9 @@ mod test_overload {
         let z = x - y;
         let grad = z.accumulate();
 
-        assert_eq!(z.value, -1.0);
-        assert_eq!(grad.wrt(&x), 1.0);
-        assert_eq!(grad.wrt(&y), -1.0);
+        assert!((z.value - -1.0).abs() < f64::EPSILON);
+        assert!((grad.wrt(&x) - 1.0).abs() < f64::EPSILON);
+        assert!((grad.wrt(&y) - -1.0).abs() < f64::EPSILON);
 
         // Variable - f64
         let g = Graph::new();
@@ -152,8 +152,8 @@ mod test_overload {
         let z = x - y;
         let grad = z.accumulate();
 
-        assert_eq!(z.value, -1.0);
-        assert_eq!(grad.wrt(&x), 1.0);
+        assert!((z.value - -1.0).abs() < f64::EPSILON);
+        assert!((grad.wrt(&x) - 1.0).abs() < f64::EPSILON);
 
         // f64 - Variable
         let g = Graph::new();
@@ -163,7 +163,7 @@ mod test_overload {
         let z = x - y;
         let grad = z.accumulate();
 
-        assert_eq!(z.value, -1.0);
-        assert_eq!(grad.wrt(&y), -1.0);
+        assert!((z.value - -1.0).abs() < f64::EPSILON);
+        assert!((grad.wrt(&y) - -1.0).abs() < f64::EPSILON);
     }
 }

--- a/src/autodiff/variables/variable.rs
+++ b/src/autodiff/variables/variable.rs
@@ -49,8 +49,9 @@ pub struct Variable<'v> {
 
 impl<'v> Variable<'v> {
     /// Instantiate a new variable.
+    #[must_use]
     #[inline]
-    pub fn new(graph: &'v Graph, index: usize, value: f64) -> Self {
+    pub const fn new(graph: &'v Graph, index: usize, value: f64) -> Self {
         Variable {
             graph,
             index,
@@ -69,66 +70,77 @@ impl<'v> Variable<'v> {
     // }
 
     /// Function to return the value contained in a vertex.
+    #[must_use]
     #[inline]
     pub fn value(&self) -> f64 {
         self.value
     }
 
     /// Function to return the index of a vertex.
+    #[must_use]
     #[inline]
     pub fn index(&self) -> usize {
         self.index
     }
 
     /// Function to return the graph.
+    #[must_use]
     #[inline]
     pub fn graph(&self) -> &'v Graph {
         self.graph
     }
 
     /// Check if variable is finite.
+    #[must_use]
     #[inline]
     pub fn is_finite(&self) -> bool {
         self.value.is_finite()
     }
 
     /// Check if variable is infinite.
+    #[must_use]
     #[inline]
     pub fn is_infinite(&self) -> bool {
         self.value.is_infinite()
     }
 
     /// Check if variable is NaN.
+    #[must_use]
     #[inline]
     pub fn is_nan(&self) -> bool {
         self.value.is_nan()
     }
 
     /// Check if variable is normal.
+    #[must_use]
     #[inline]
     pub fn is_normal(&self) -> bool {
         self.value.is_normal()
     }
 
     /// Check if variable is subnormal.
+    #[must_use]
     #[inline]
     pub fn is_subnormal(&self) -> bool {
         self.value.is_subnormal()
     }
 
     /// Check if variable is zero.
+    #[must_use]
     #[inline]
     pub fn is_zero(&self) -> bool {
         self.value == 0.0
     }
 
     /// Check if variable is positive.
+    #[must_use]
     #[inline]
     pub fn is_positive(&self) -> bool {
         self.value.is_sign_positive()
     }
 
     /// Check if variable is negative.
+    #[must_use]
     #[inline]
     pub fn is_negative(&self) -> bool {
         self.value.is_sign_negative()
@@ -141,6 +153,7 @@ impl<'v> Variable<'v> {
     }
 
     /// Returns the sign of the variable.
+    #[must_use]
     #[inline]
     pub fn signum(&self) -> f64 {
         self.value.signum()
@@ -196,6 +209,7 @@ impl<'v> Ord for Variable<'v> {
 #[cfg(test)]
 mod tests_variable {
     use super::*;
+    use crate::assert_approx_equal;
 
     #[test]
     fn test_value() {
@@ -205,7 +219,7 @@ mod tests_variable {
             index: 5,
             value: std::f64::consts::PI,
         };
-        assert_eq!(var.value(), std::f64::consts::PI);
+        assert_approx_equal!(var.value(), std::f64::consts::PI, f64::EPSILON);
     }
 
     #[test]
@@ -227,7 +241,7 @@ mod tests_variable {
             index: 5,
             value: std::f64::consts::PI,
         };
-        assert_eq!(var.graph() as *const _, &graph as *const _);
+        assert_eq!(var.graph() as *const _, std::ptr::addr_of!(graph));
     }
 
     #[test]
@@ -260,6 +274,6 @@ mod tests_variable {
         assert!(!g.var(1.0).is_zero());
         assert!(g.var(1.0).is_positive());
         assert!(!g.var(1.0).is_negative());
-        assert_eq!(g.var(1.0).signum(), 1.0);
+        assert_approx_equal!(g.var(1.0).signum(), 1.0, f64::EPSILON);
     }
 }

--- a/src/autodiff/vertex.rs
+++ b/src/autodiff/vertex.rs
@@ -31,6 +31,7 @@ pub struct Vertex {
 ///     - A binary operation has two parents.
 ///     - A unary operation has one parent.
 ///     - A nullary operation has no parents.
+#[derive(Copy, Clone, Debug)]
 pub enum Arity {
     /// Nullary operation (e.g. a constant).
     /// This has no parents.
@@ -66,17 +67,25 @@ enum Operation {
 
 impl Vertex {
     /// Get the partials of the vertex.
-    pub fn get_partials(&self) -> [f64; 2] {
+    #[must_use]
+    pub const fn get_partials(&self) -> [f64; 2] {
         self.partials
     }
 
     /// Get the parents of the vertex.
-    pub fn get_parents(&self) -> [usize; 2] {
+    #[must_use]
+    pub const fn get_parents(&self) -> [usize; 2] {
         self.parents
     }
 
     /// Instantiate a new vertex from a binary operation.
-    pub fn new_binary(partial_x: f64, parent_x: usize, partial_y: f64, parent_y: usize) -> Self {
+    #[must_use]
+    pub const fn new_binary(
+        partial_x: f64,
+        parent_x: usize,
+        partial_y: f64,
+        parent_y: usize,
+    ) -> Self {
         Self {
             partials: [partial_x, partial_y],
             parents: [parent_x, parent_y],
@@ -84,7 +93,8 @@ impl Vertex {
     }
 
     /// Instantiate a new vertex from a unary operation.
-    pub fn new_unary(partial_x: f64, parent_x: usize) -> Self {
+    #[must_use]
+    pub const fn new_unary(partial_x: f64, parent_x: usize) -> Self {
         Self {
             partials: [partial_x, 0.0],
             parents: [parent_x, 0],
@@ -92,7 +102,8 @@ impl Vertex {
     }
 
     /// Instantiate a new vertex from a nullary operation.
-    pub fn new_nullary() -> Self {
+    #[must_use]
+    pub const fn new_nullary() -> Self {
         Self {
             partials: [0.0; 2],
             parents: [0; 2],

--- a/src/curves/curve.rs
+++ b/src/curves/curve.rs
@@ -20,6 +20,7 @@ use time::OffsetDateTime;
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// A trait for curve models.
+#[allow(clippy::module_name_repetitions)]
 pub trait CurveModel {
     /// Returns the forward rate for a given date.
     fn forward_rate(&self, date: OffsetDateTime) -> f64;
@@ -31,6 +32,7 @@ pub trait CurveModel {
     fn discount_factor(&self, date: OffsetDateTime) -> f64;
 
     /// Calibrates the model to a set of market rates.
+    #[must_use]
     fn calibrate<C: Curve>(&self, curve: C) -> Self;
 }
 
@@ -96,7 +98,7 @@ pub trait Curve {
     }
 
     /// Returns multiple discount factors for the given dates.
-    /// This is a convenience function that calls [discount_factor] for each
+    /// This is a convenience function that calls `discount_factor` for each
     /// date.
     fn discount_factors(&self, dates: &[OffsetDateTime]) -> Vec<f64> {
         dates
@@ -106,6 +108,7 @@ pub trait Curve {
     }
 }
 
+#[allow(clippy::module_name_repetitions)]
 /// Yield curve struct.
 pub struct YieldCurve {
     /// Map of dates and rates.
@@ -118,6 +121,7 @@ pub struct YieldCurve {
 }
 
 /// Curve error enum.
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Copy)]
 pub enum CurveError {
     /// The date is outside the curve's range.
@@ -133,6 +137,7 @@ pub enum CurveError {
 
 impl YieldCurve {
     /// Creates a new yield curve.
+    #[must_use]
     pub fn new(rates: BTreeMap<OffsetDateTime, f64>) -> Self {
         Self { rates }
     }
@@ -147,10 +152,12 @@ impl Curve for YieldCurve {
         *self.rates.keys().max().unwrap()
     }
 
+    #[allow(clippy::similar_names)]
     fn update_rate(&mut self, date: OffsetDateTime, rate: f64) {
         self.rates.insert(date, rate);
     }
 
+    #[allow(clippy::similar_names)]
     fn from_dates_and_rates(dates: &[OffsetDateTime], rates: &[f64]) -> Self {
         let mut rates_map = BTreeMap::new();
 
@@ -161,6 +168,7 @@ impl Curve for YieldCurve {
         Self { rates: rates_map }
     }
 
+    #[allow(clippy::similar_names)]
     fn from_initial_date_rates_and_durations(
         initial_date: OffsetDateTime,
         rates: &[f64],
@@ -168,7 +176,7 @@ impl Curve for YieldCurve {
     ) -> Self {
         let mut dates = vec![initial_date];
 
-        for duration in durations.iter() {
+        for duration in durations {
             dates.push(*dates.last().unwrap() + *duration);
         }
 
@@ -272,6 +280,7 @@ mod tests_curves {
         assert_eq!(interval3, (date3, date3));
     }
 
+    #[allow(clippy::similar_names)]
     #[test]
     fn test_yield_curve_discount_factor() {
         // Initial date of the curve.

--- a/src/curves/nelson_siegel.rs
+++ b/src/curves/nelson_siegel.rs
@@ -29,8 +29,9 @@ pub struct NelsonSiegel {
 
 impl NelsonSiegel {
     /// Create a new Nelson-Siegel model.
-    pub fn new(beta0: f64, beta1: f64, beta2: f64, lambda: f64) -> Self {
-        NelsonSiegel {
+    #[must_use]
+    pub const fn new(beta0: f64, beta1: f64, beta2: f64, lambda: f64) -> Self {
+        Self {
             beta0,
             beta1,
             beta2,

--- a/src/curves/nelson_siegel_svensson.rs
+++ b/src/curves/nelson_siegel_svensson.rs
@@ -31,7 +31,15 @@ pub struct NelsonSiegelSvensson {
 
 impl NelsonSiegelSvensson {
     /// Create a new Nelson-Siegel model.
-    pub fn new(beta0: f64, beta1: f64, beta2: f64, beta3: f64, lambda1: f64, lambda2: f64) -> Self {
+    #[must_use]
+    pub const fn new(
+        beta0: f64,
+        beta1: f64,
+        beta2: f64,
+        beta3: f64,
+        lambda1: f64,
+        lambda2: f64,
+    ) -> Self {
         Self {
             beta0,
             beta1,

--- a/src/curves/surface.rs
+++ b/src/curves/surface.rs
@@ -27,6 +27,7 @@ pub trait Surface {
 /// space dimension (e.g. strike or moneyness) and a time dimension (e.g. dates).
 ///
 /// We represent this as a map from time to a curve of volatilities.
+#[allow(clippy::module_name_repetitions)]
 pub struct VolatilitySurface<C: Curve> {
     /// The volatilities of the surface.
     pub volatilities: BTreeMap<f64, C>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,11 +7,12 @@
 //      - LICENSE-MIT.md
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-//! RustQuant error handling module.
+//! `RustQuant` error handling module.
 //! A custom error type `RustQuantError` is defined, along with a macro to create an error,
 //! that propagates a `RustQuantError` with the text to include in the output.
 
-/// Error type for RustQuant.
+/// Error type for `RustQuant`.
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, thiserror::Error)]
 pub enum RustQuantError {
     /// This error indicates that an problem occurred in the computation.

--- a/src/instruments/bonds/bond.rs
+++ b/src/instruments/bonds/bond.rs
@@ -22,6 +22,7 @@ use time::{Duration, OffsetDateTime};
 /// A zero-coupon bond (aka a pure discount bond or simply a zero) is a
 /// debt security that doesn't pay interest (a coupon) periodically but
 /// instead pays the principal in full at maturity.
+#[allow(clippy::module_name_repetitions)]
 pub struct ZeroCouponBond {
     /// The date the bond is evaluated (i.e. priced).
     pub evaluation_date: OffsetDateTime,
@@ -45,6 +46,7 @@ pub struct ZeroCouponBond {
 /// - A 6-month zero-coupon bond with a face value of $2.50.
 /// - A 12-month zero-coupon bond with a face value of $2.50.
 /// - An 18-month zero-coupon bond with a face value of $102.50.
+#[allow(clippy::module_name_repetitions)]
 pub struct CouponBond {
     /// The date the bond is evaluated (i.e. priced).
     pub evaluation_date: OffsetDateTime,
@@ -138,7 +140,7 @@ impl Instrument for CouponBond {
             &self
                 .coupons
                 .keys()
-                .cloned()
+                .copied()
                 .collect::<Vec<OffsetDateTime>>(),
         );
         // .iter()
@@ -175,10 +177,11 @@ impl CouponBond2 {
     /// Validate the dates.
     /// All evaluation dates must be the same, since it is a single instrument,
     /// we just happen to be treating it as a portfolio of zero-coupon bonds.
+    #[must_use]
     pub fn validate_dates(&self) -> bool {
         let mut evaluation_date: Option<OffsetDateTime> = None;
 
-        for (_, bond) in self.coupons.iter() {
+        for bond in self.coupons.values() {
             if evaluation_date.is_none() {
                 evaluation_date = Some(bond.evaluation_date);
             } else if evaluation_date != Some(bond.evaluation_date) {
@@ -202,6 +205,7 @@ mod tests_bond {
 
     use super::*;
 
+    #[allow(clippy::similar_names)]
     fn create_test_yield_curve(t0: OffsetDateTime) -> YieldCurve {
         // Create a treasury yield curve with 8 points (3m, 6m, 1y, 2y, 5y, 10y, 30y).
         // Values from Bloomberg: <https://www.bloomberg.com/markets/rates-bonds/government-bonds/us>

--- a/src/instruments/options/asian.rs
+++ b/src/instruments/options/asian.rs
@@ -10,7 +10,7 @@
 use time::OffsetDateTime;
 
 use crate::{
-    statistics::distributions::{gaussian::*, Distribution},
+    statistics::distributions::{gaussian::Gaussian, Distribution},
     time::{DayCountConvention, DayCounter},
 };
 
@@ -19,6 +19,7 @@ use crate::{
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Type of Asian option (fixed or floating strike).
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Copy)]
 pub enum AsianStrike {
     /// Floating strike Asian option.
@@ -47,6 +48,7 @@ pub enum AveragingMethod {
 }
 
 /// Asian Option struct.
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Copy)]
 pub struct AsianOption {
     /// `S` - Initial price of the underlying.
@@ -71,7 +73,8 @@ pub struct AsianOption {
 
 impl AsianOption {
     /// New Asian Option
-    pub fn new(
+    #[must_use]
+    pub const fn new(
         initial_price: f64,
         strike_price: f64,
         risk_free_rate: f64,
@@ -92,6 +95,7 @@ impl AsianOption {
     }
 
     /// Geometric Continuous Average-Rate Price
+    #[must_use]
     pub fn price_geometric_average(&self) -> (f64, f64) {
         let S = self.initial_price;
         let K = self.strike_price;

--- a/src/instruments/options/bachelier.rs
+++ b/src/instruments/options/bachelier.rs
@@ -40,6 +40,7 @@ pub struct Bachelier {
 }
 
 /// Bachelier European Option pricing model.
+#[allow(clippy::module_name_repetitions)]
 pub struct ModifiedBachelier {
     /// The underlying asset price.
     pub underlying_price: f64,
@@ -67,6 +68,7 @@ pub struct ModifiedBachelier {
 
 impl Bachelier {
     /// New Bachelier European Option
+    #[must_use]
     pub fn new(
         underlying_price: f64,
         strike_price: f64,
@@ -86,6 +88,7 @@ impl Bachelier {
     }
 
     /// Bachelier European Option price.
+    #[must_use]
     pub fn price(&self) -> f64 {
         let S = self.underlying_price;
         let K = self.strike_price;
@@ -111,7 +114,9 @@ impl Bachelier {
 
 impl ModifiedBachelier {
     /// New Modified Bachelier European Option
-    pub fn new(
+    #[allow(clippy::too_many_arguments)]
+    #[must_use]
+    pub const fn new(
         underlying_price: f64,
         strike_price: f64,
         volatility: f64,
@@ -134,6 +139,7 @@ impl ModifiedBachelier {
     }
 
     /// Modified Bachelier European Option price.
+    #[must_use]
     pub fn price(&self) -> f64 {
         let S = self.underlying_price;
         let K = self.strike_price;
@@ -178,7 +184,7 @@ mod tests_bachelier {
             OffsetDateTime::now_utc() + Duration::days(365),
             TypeFlag::Call,
         );
-        assert_approx_equal!(bachelier.price(), 0.07967908186015137, 1e-10);
+        assert_approx_equal!(bachelier.price(), 0.079_679_081_860_151_37, 1e-10);
     }
 
     #[test]
@@ -193,6 +199,6 @@ mod tests_bachelier {
             OffsetDateTime::now_utc() + Duration::days(365),
             TypeFlag::Call,
         );
-        assert_approx_equal!(bachelier.price(), 2.511692140521875, 1e-10);
+        assert_approx_equal!(bachelier.price(), 2.511_692_140_521_875, 1e-10);
     }
 }

--- a/src/instruments/options/barrier.rs
+++ b/src/instruments/options/barrier.rs
@@ -7,7 +7,7 @@
 //      - LICENSE-MIT.md
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use crate::statistics::distributions::{gaussian::*, Distribution};
+use crate::statistics::distributions::{gaussian::Gaussian, Distribution};
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // BARRIER OPTION STRUCT
@@ -15,6 +15,7 @@ use crate::statistics::distributions::{gaussian::*, Distribution};
 
 /// Barrier Option struct for parameters and pricing methods.
 #[derive(Debug, Clone, Copy)]
+#[allow(clippy::module_name_repetitions)]
 pub struct BarrierOption {
     /// * `S` - Initial underlying price.
     pub initial_price: f64,
@@ -36,6 +37,7 @@ pub struct BarrierOption {
 
 /// Barrier option type enum.
 #[derive(Debug, Clone, Copy)]
+#[allow(clippy::module_name_repetitions)]
 pub enum BarrierType {
     /// Call (up-and-in)
     /// Payoff: `max(S_T - X, 0) * I(max(S_t) > H)`
@@ -78,6 +80,7 @@ impl BarrierOption {
     ///
     /// # Note:
     /// * `b = r - q` - The cost of carry.
+    #[must_use]
     pub fn price(&self, type_flag: BarrierType) -> f64 {
         let S = self.initial_price;
         let X = self.strike_price;
@@ -204,6 +207,8 @@ mod tests {
     use super::*;
     use crate::assert_approx_equal;
 
+    use std::f64::EPSILON as EPS;
+
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // Initial underlying price ABOVE the barrier.
     //
@@ -223,6 +228,7 @@ mod tests {
         dividend_yield: 0.01,
     };
 
+    #[allow(clippy::similar_names)]
     #[test]
     fn test_S_above_H() {
         let cdi = S_ABOVE_H.price(BarrierType::CDI);
@@ -230,31 +236,31 @@ mod tests {
         let pdi = S_ABOVE_H.price(BarrierType::PDI);
         let pdo = S_ABOVE_H.price(BarrierType::PDO);
 
-        assert_approx_equal!(cdi, 9.504815, 0.000001);
-        assert_approx_equal!(cdo, 7.295022, 0.000001);
-        assert_approx_equal!(pdi, 3.017298, 0.000001);
-        assert_approx_equal!(pdo, 0.000000, 0.000001);
+        assert_approx_equal!(cdi, 9.504_815_211_050_698, EPS);
+        assert_approx_equal!(cdo, 7.295_021_649_666_765, EPS);
+        assert_approx_equal!(pdi, 3.017_297_598_380_377_4, EPS);
+        assert_approx_equal!(pdo, 0.000_000, EPS);
     }
 
     #[test]
     #[should_panic(expected = "Barrier touched - check barrier and type flag.")]
     fn cui_panic() {
-        S_ABOVE_H.price(BarrierType::CUI);
+        let _ = S_ABOVE_H.price(BarrierType::CUI);
     }
     #[test]
     #[should_panic(expected = "Barrier touched - check barrier and type flag.")]
     fn cuo_panic() {
-        S_ABOVE_H.price(BarrierType::CUO);
+        let _ = S_ABOVE_H.price(BarrierType::CUO);
     }
     #[test]
     #[should_panic(expected = "Barrier touched - check barrier and type flag.")]
     fn pui_panic() {
-        S_ABOVE_H.price(BarrierType::PUI);
+        let _ = S_ABOVE_H.price(BarrierType::PUI);
     }
     #[test]
     #[should_panic(expected = "Barrier touched - check barrier and type flag.")]
     fn puo_panic() {
-        S_ABOVE_H.price(BarrierType::PUO);
+        let _ = S_ABOVE_H.price(BarrierType::PUO);
     }
 
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -276,6 +282,7 @@ mod tests {
         dividend_yield: 0.01,
     };
 
+    #[allow(clippy::similar_names)]
     #[test]
     fn test_S_below_H() {
         let cui = S_BELOW_H.price(BarrierType::CUI);
@@ -283,30 +290,30 @@ mod tests {
         let pui = S_BELOW_H.price(BarrierType::PUI);
         let puo = S_BELOW_H.price(BarrierType::PUO);
 
-        assert_approx_equal!(cui, 4.692603, 0.000001);
-        assert_approx_equal!(cuo, 0.022449, 0.000001);
-        assert_approx_equal!(pui, 1.359553, 0.000001);
-        assert_approx_equal!(puo, 9.373956, 0.000001);
+        assert_approx_equal!(cui, 4.692_603_355_387_815, EPS);
+        assert_approx_equal!(cuo, 0.022_448_676_101_445_74, EPS);
+        assert_approx_equal!(pui, 1.359_553_168_024_573_8, EPS);
+        assert_approx_equal!(puo, 9.373_956_276_110_954, EPS);
     }
 
     #[test]
     #[should_panic(expected = "Barrier touched - check barrier and type flag.")]
     fn cdi_panic() {
-        S_BELOW_H.price(BarrierType::CDI);
+        let _ = S_BELOW_H.price(BarrierType::CDI);
     }
     #[test]
     #[should_panic(expected = "Barrier touched - check barrier and type flag.")]
     fn cdo_panic() {
-        S_BELOW_H.price(BarrierType::CDO);
+        let _ = S_BELOW_H.price(BarrierType::CDO);
     }
     #[test]
     #[should_panic(expected = "Barrier touched - check barrier and type flag.")]
     fn pdi_panic() {
-        S_BELOW_H.price(BarrierType::PDI);
+        let _ = S_BELOW_H.price(BarrierType::PDI);
     }
     #[test]
     #[should_panic(expected = "Barrier touched - check barrier and type flag.")]
     fn pdo_panic() {
-        S_BELOW_H.price(BarrierType::PDO);
+        let _ = S_BELOW_H.price(BarrierType::PDO);
     }
 }

--- a/src/instruments/options/binary.rs
+++ b/src/instruments/options/binary.rs
@@ -9,7 +9,7 @@
 
 //! This module contains various 'binary', or 'digital', option types.
 
-use crate::statistics::distributions::{gaussian::*, Distribution};
+use crate::statistics::distributions::{gaussian::Gaussian, Distribution};
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // STRUCTS
@@ -63,8 +63,9 @@ pub struct CashOrNothingOption {
 
 impl GapOption {
     /// Gap option pricer.
-    /// The payoff from a call is 0 if S < K_1 and S — K_2 if S > K_1.
-    /// Similarly, the payoff from a put is 0 if S > K_1 and K_2 — S if S < K_1.
+    /// The payoff from a call is $0$ if $S < K_1$ and $S — K_2$ if $S > K_1$.
+    /// Similarly, the payoff from a put is $0$ if $S > K_1$ and $K_2 — S$ if $S < K_1$.
+    #[must_use]
     pub fn price(&self) -> (f64, f64) {
         let S = self.initial_price;
         let K_1 = self.strike_1;
@@ -90,6 +91,7 @@ impl CashOrNothingOption {
     /// Cah-or-Nothing option pricer.
     /// The payoff from a call is 0 if S < X and K if S > X.
     /// The payoff from a put is 0 if S > X and K if S < X.
+    #[must_use]
     pub fn price(&self) -> (f64, f64) {
         let S = self.initial_price;
         let X = self.strike_price;
@@ -118,6 +120,7 @@ impl CashOrNothingOption {
 mod tests {
     use super::*;
     use crate::assert_approx_equal;
+    use std::f64::EPSILON as EPS;
 
     #[test]
     fn test_gap_option() {
@@ -134,7 +137,7 @@ mod tests {
         let prices = gap.price();
 
         // Value from Haug's book (note: gap option payoffs can be negative).
-        assert_approx_equal!(prices.0, -0.0053, 0.0001);
+        assert_approx_equal!(prices.0, -0.005_252_489_258_779_747, EPS);
     }
 
     #[test]
@@ -152,6 +155,6 @@ mod tests {
         let prices = CON.price();
 
         // Value from Haug's book.
-        assert_approx_equal!(prices.1, 2.6710, 0.0001);
+        assert_approx_equal!(prices.1, 2.671_045_684_461_347, EPS);
     }
 }

--- a/src/instruments/options/binomial.rs
+++ b/src/instruments/options/binomial.rs
@@ -14,6 +14,7 @@
 use super::{ExerciseFlag, TypeFlag};
 
 /// Struct containing the parameters to price an option via binomial tree method.
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Copy)]
 pub struct BinomialOption {
     initial_price: f64,
@@ -43,6 +44,7 @@ impl BinomialOption {
     /// # Note:
     ///
     /// * `b = r - q` - The cost of carry.
+    #[must_use]
     pub fn price_CoxRossRubinstein(
         &self,
         output_flag: &str,
@@ -76,15 +78,16 @@ impl BinomialOption {
         Df = (-r * dt).exp();
 
         for i in 0..option_value.capacity() {
-            option_value
-                .push((z as f64 * (S * u.powi(i as i32) * d.powi((n - i) as i32) - K)).max(0.0));
+            option_value.push(
+                (f64::from(z) * (S * u.powi(i as i32) * d.powi((n - i) as i32) - K)).max(0.0),
+            );
         }
 
         for j in (0..n).rev() {
             for i in 0..=j {
                 match ame_eur_flag {
                     ExerciseFlag::American => {
-                        option_value[i] = (z as f64
+                        option_value[i] = (f64::from(z)
                             * (S * u.powi(i as i32) * d.powi(j as i32 - i as i32) - K))
                             .max(Df * (p * (option_value[i + 1]) + (1.0 - p) * option_value[i]));
                     }

--- a/src/instruments/options/black_scholes_merton.rs
+++ b/src/instruments/options/black_scholes_merton.rs
@@ -98,6 +98,8 @@ impl Instrument for BlackScholesMerton {
 
 impl BlackScholesMerton {
     /// New European Option
+    #[allow(clippy::too_many_arguments)]
+    #[must_use]
     pub fn new(
         cost_of_carry: f64,
         underlying_price: f64,
@@ -121,6 +123,7 @@ impl BlackScholesMerton {
     }
 
     /// Generalised Black-Scholes European Option Price.
+    #[must_use]
     pub fn price(&self) -> f64 {
         let (S, K, _, r, b) = self.unpack();
         let T = self.year_fraction();
@@ -136,6 +139,7 @@ impl BlackScholesMerton {
     }
 
     // Compute the year fraction between two dates.
+    #[must_use]
     fn year_fraction(&self) -> f64 {
         DayCounter::day_count_factor(
             self.evaluation_date.unwrap_or(OffsetDateTime::now_utc()),
@@ -145,6 +149,7 @@ impl BlackScholesMerton {
     }
 
     // Compute d1 and d2.
+    #[must_use]
     fn d1_d2(&self) -> (f64, f64) {
         let (S, K, v, _, b) = self.unpack();
 
@@ -158,6 +163,7 @@ impl BlackScholesMerton {
     }
 
     // Unpack struct to get option parameters.
+    #[must_use]
     fn unpack(&self) -> (f64, f64, f64, f64, f64) {
         (
             self.underlying_price,
@@ -169,6 +175,7 @@ impl BlackScholesMerton {
     }
 
     /// Delta of generalised Black-Scholes European Option.
+    #[must_use]
     pub fn delta(&self) -> f64 {
         let (_, _, _, r, b) = self.unpack();
         let T = self.year_fraction();
@@ -183,6 +190,7 @@ impl BlackScholesMerton {
 
     /// Vanna of generalised Black-Scholes European Option.
     /// Also known as DdeltaDvol.
+    #[must_use]
     pub fn vanna(&self) -> f64 {
         let (_, _, v, r, b) = self.unpack();
         let T = self.year_fraction();
@@ -194,6 +202,7 @@ impl BlackScholesMerton {
 
     /// Charm of generalised Black-Scholes European Option.
     /// Also known as DdeltaDtime, delta decay or delta bleed.
+    #[must_use]
     pub fn charm(&self) -> f64 {
         let (_, _, v, r, b) = self.unpack();
         let T = self.year_fraction();
@@ -214,12 +223,14 @@ impl BlackScholesMerton {
 
     /// Lambda of generalised Black-Scholes European Option.
     /// Also known as elasticity or leverage.
+    #[must_use]
     pub fn lambda(&self) -> f64 {
         self.delta() * self.underlying_price / self.price()
     }
 
     /// Gamma of generalised Black-Scholes European Option.
     /// Also known as convexity.
+    #[must_use]
     pub fn gamma(&self) -> f64 {
         let n = Gaussian::default();
         let (S, _, v, r, b) = self.unpack();
@@ -230,24 +241,28 @@ impl BlackScholesMerton {
     }
 
     /// Gamma percent of generalised Black-Scholes European Option.
+    #[must_use]
     pub fn gamma_percent(&self) -> f64 {
         self.gamma() * self.underlying_price / 100.0
     }
 
     /// Zomma of generalised Black-Scholes European Option.
     /// Also known as DgammaDvol.
+    #[must_use]
     pub fn zomma(&self) -> f64 {
         let (d1, d2) = self.d1_d2();
         self.gamma() * ((d1 * d2 - 1.0) / self.volatility)
     }
 
     /// Zomma percent of generalised Black-Scholes European Option.
+    #[must_use]
     pub fn zomma_percent(&self) -> f64 {
         self.zomma() * self.underlying_price / 100.0
     }
 
     /// Speed of generalised Black-Scholes European Option.
     /// Also known as DgammaDspot.
+    #[must_use]
     pub fn speed(&self) -> f64 {
         let (S, _, v, _, _) = self.unpack();
         let T = self.year_fraction();
@@ -260,6 +275,7 @@ impl BlackScholesMerton {
 
     /// Colour of generalised Black-Scholes European Option.
     /// Also known as DgammaDtime.
+    #[must_use]
     pub fn colour(&self) -> f64 {
         let (_, _, v, r, b) = self.unpack();
         let T = self.year_fraction();
@@ -272,6 +288,7 @@ impl BlackScholesMerton {
 
     /// Vega of generalised Black-Scholes European Option.
     /// Also known as zeta.
+    #[must_use]
     pub fn vega(&self) -> f64 {
         let (S, _, _, r, b) = self.unpack();
         let T = self.year_fraction();
@@ -284,6 +301,7 @@ impl BlackScholesMerton {
 
     /// Vomma of generalised Black-Scholes European Option.
     /// Also known as DvegaDvol.
+    #[must_use]
     pub fn vomma(&self) -> f64 {
         let (d1, d2) = self.d1_d2();
 
@@ -292,6 +310,7 @@ impl BlackScholesMerton {
 
     /// Ultima of generalised Black-Scholes European Option.
     /// Also known as DvommaDvol.
+    #[must_use]
     pub fn ultima(&self) -> f64 {
         let (d1, d2) = self.d1_d2();
 
@@ -300,6 +319,7 @@ impl BlackScholesMerton {
 
     /// Vega Bleed of the generalised Black-Scholes European option.
     /// Also known as DvegaDtime.
+    #[must_use]
     pub fn vega_bleed(&self) -> f64 {
         let (_, _, v, r, b) = self.unpack();
         let T = self.year_fraction();
@@ -310,6 +330,7 @@ impl BlackScholesMerton {
 
     /// Theta of the generalised Black-Scholes European option.
     /// Also known as Expected Bleed.
+    #[must_use]
     pub fn theta(&self) -> f64 {
         let (S, K, v, r, b) = self.unpack();
         let T = self.year_fraction();
@@ -332,6 +353,7 @@ impl BlackScholesMerton {
     }
 
     /// Rho of the generalised Black-Scholes European option.
+    #[must_use]
     pub fn rho(&self) -> f64 {
         let T = self.year_fraction();
 
@@ -353,6 +375,7 @@ impl BlackScholesMerton {
 
     /// Phi of the generalised Black-Scholes European option.
     /// Also known as Rho-2.
+    #[must_use]
     pub fn phi(&self) -> f64 {
         let (S, _, _, r, b) = self.unpack();
         let T = self.year_fraction();
@@ -367,6 +390,7 @@ impl BlackScholesMerton {
 
     /// Zeta of the generalised Black-Scholes European option.
     /// Also known as the in-the-money probability.
+    #[must_use]
     pub fn zeta(&self) -> f64 {
         let n = Gaussian::default();
 
@@ -378,6 +402,7 @@ impl BlackScholesMerton {
 
     /// Strike Delta of the generalised Black-Scholes European option.
     /// Also known as Dual Delta or Discounted Probability.
+    #[must_use]
     pub fn strike_delta(&self) -> f64 {
         let n = Gaussian::default();
 
@@ -390,6 +415,7 @@ impl BlackScholesMerton {
     }
 
     /// Strike Gamma of the generalised Black-Scholes European option.
+    #[must_use]
     pub fn strike_gamma(&self) -> f64 {
         let n = Gaussian::default();
         let T = self.year_fraction();
@@ -407,6 +433,7 @@ impl BlackScholesMerton {
 mod tests_black_scholes_merton {
     use super::*;
     use crate::assert_approx_equal;
+    use std::f64::EPSILON as EPS;
     use time::Duration;
 
     #[test]
@@ -422,7 +449,7 @@ mod tests_black_scholes_merton {
             OffsetDateTime::now_utc() + Duration::days(91),
             TypeFlag::Call,
         );
-        assert_approx_equal!(bsm.price(), 2.1044558953508385, 1e-10);
+        assert_approx_equal!(bsm.price(), 2.104_455_895_350_838_5, EPS);
     }
 
     #[test]
@@ -438,6 +465,6 @@ mod tests_black_scholes_merton {
             OffsetDateTime::now_utc() + Duration::days(182),
             TypeFlag::Put,
         );
-        assert_approx_equal!(bsm.price(), 2.4524152213972776, 1e-10);
+        assert_approx_equal!(bsm.price(), 2.452_415_221_397_277_6, EPS);
     }
 }

--- a/src/instruments/options/european.rs
+++ b/src/instruments/options/european.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 
 /// Black-Scholes Vanilla European Option
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Copy)]
 pub struct EuropeanOption {
     /// `S` - Initial price of the underlying.
@@ -43,6 +44,7 @@ pub struct EuropeanOption {
 
 impl EuropeanOption {
     /// New European Option
+    #[must_use]
     pub fn new(
         initial_price: f64,
         strike_price: f64,
@@ -67,6 +69,7 @@ impl EuropeanOption {
     /// Returns a tuple: `(call_price, put_price)`
     /// # Note:
     /// * `b = r - q` - The cost of carry.
+    #[must_use]
     pub fn price(&self) -> (f64, f64) {
         let S = self.initial_price;
         let K = self.strike_price;

--- a/src/instruments/options/forward_start.rs
+++ b/src/instruments/options/forward_start.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 
 /// Forward Start Option parameters struct
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug)]
 pub struct ForwardStartOption {
     /// `S` - Initial price of the underlying.
@@ -53,6 +54,7 @@ impl ForwardStartOption {
     /// Returns a tuple: `(call_price, put_price)`
     /// # Note:
     /// * `b = r - q` - The cost of carry.
+    #[must_use]
     pub fn price(&self) -> (f64, f64) {
         let S = self.initial_price;
         let a = self.alpha;

--- a/src/instruments/options/greeks.rs
+++ b/src/instruments/options/greeks.rs
@@ -9,7 +9,7 @@
 
 use time::OffsetDateTime;
 
-use crate::instruments::options::european::*;
+use crate::instruments::options::european::EuropeanOption;
 use crate::statistics::distributions::{Distribution, Gaussian};
 use crate::time::{DayCountConvention, DayCounter};
 
@@ -50,6 +50,7 @@ impl Greeks {
     ///
     /// # Arguments:
     /// * `option` - A `EuropeanOption` struct containing the parameters.
+    #[must_use]
     pub fn compute(option: EuropeanOption) -> Self {
         let S = option.initial_price;
         let K = option.strike_price;
@@ -150,7 +151,7 @@ mod tests_greeks {
         for strike in 1..=100 {
             let option = EuropeanOption {
                 initial_price: 100.0,
-                strike_price: strike as f64,
+                strike_price: f64::from(strike),
                 risk_free_rate: 0.05,
                 volatility: 0.2,
                 dividend_rate: 0.03,

--- a/src/instruments/options/heston.rs
+++ b/src/instruments/options/heston.rs
@@ -8,7 +8,7 @@
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 use crate::{
-    math::*,
+    math::integrate,
     time::{DayCountConvention, DayCounter},
 };
 use num_complex::Complex;
@@ -20,6 +20,7 @@ use time::OffsetDateTime;
 
 /// Heston model for option pricing.
 #[allow(clippy::too_many_arguments)]
+#[must_use]
 pub fn heston(
     S0: f64,    // Initial asset value.
     V0: f64,    // Initial variance value.
@@ -152,6 +153,7 @@ mod tests {
     use crate::assert_approx_equal;
 
     use super::*;
+    use std::f64::EPSILON as EPS;
 
     #[test]
     fn test_heston_options() {
@@ -172,9 +174,9 @@ mod tests {
             expiry_date,
         );
         // Call price.
-        assert_approx_equal!(heston1.0, 6.2442, 1e-4);
+        assert_approx_equal!(heston1.0, 6.244_175_780_382_292, EPS);
         // Put price.
-        assert_approx_equal!(heston1.1, 5.7517, 1e-4);
+        assert_approx_equal!(heston1.1, 5.751_722_351_735_211, EPS);
 
         // WITHOUT DIVIDEND YIELD.
         let heston2 = heston(
@@ -191,8 +193,8 @@ mod tests {
             expiry_date,
         );
         // Call price.
-        assert_approx_equal!(heston2.0, 6.8575, 1e-4);
+        assert_approx_equal!(heston2.0, 6.857_458_545_841_29, EPS);
         // Put price.
-        assert_approx_equal!(heston2.1, 5.3727, 1e-4);
+        assert_approx_equal!(heston2.1, 5.372_700_994_566_344, EPS);
     }
 }

--- a/src/instruments/options/option.rs
+++ b/src/instruments/options/option.rs
@@ -44,6 +44,7 @@ pub enum StrikeFlag {
 /// Contains the common parameters (as in Black-Scholes).
 /// Other option types may have additional parameters,
 /// such as lookback options (S_min, S_max).
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone)]
 pub struct OptionParameters {
     /// `S` - Initial price of the underlying.
@@ -62,7 +63,8 @@ pub struct OptionParameters {
 
 impl OptionParameters {
     /// New option parameters struct initialiser.
-    pub fn new(
+    #[must_use]
+    pub const fn new(
         initial_price: Vec<f64>,
         strike_price: Vec<f64>,
         risk_free_rate: Vec<f64>,

--- a/src/instruments/options/power.rs
+++ b/src/instruments/options/power.rs
@@ -20,6 +20,7 @@ use time::OffsetDateTime;
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Power Option contract.
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Copy)]
 pub struct PowerOption {
     /// `S` - Initial price of the underlying.
@@ -48,6 +49,8 @@ pub struct PowerOption {
 
 impl PowerOption {
     /// New Power Option contract.
+    #[allow(clippy::too_many_arguments)]
+    #[must_use]
     pub fn new(
         initial_price: f64,
         strike_price: f64,
@@ -71,6 +74,7 @@ impl PowerOption {
     }
 
     /// Power Option price.
+    #[must_use]
     pub fn price(&self) -> f64 {
         let S = self.initial_price;
         let K = self.strike_price;
@@ -100,6 +104,8 @@ mod tests_power_contract {
     use crate::assert_approx_equal;
     use time::Duration;
 
+    use std::f64::EPSILON as EPS;
+
     #[test]
     fn test_power() {
         let power_option = PowerOption {
@@ -113,6 +119,6 @@ mod tests_power_contract {
             expiration_date: OffsetDateTime::now_utc() + Duration::days(182),
         };
 
-        assert_approx_equal!(power_option.price(), 0.8313226401449854, 1e-10);
+        assert_approx_equal!(power_option.price(), 0.831_322_640_144_985_4, EPS);
     }
 }

--- a/src/iso/iso_3166.rs
+++ b/src/iso/iso_3166.rs
@@ -28,21 +28,26 @@ pub struct ISO_3166 {
 
 impl ISO_3166 {
     /// Returns the ISO 3166-1 alpha-2 country code.
+    #[must_use]
     pub fn alpha_2(&self) -> &'static str {
         self.alpha_2
     }
 
     /// Returns the ISO 3166-1 alpha-3 country code.
+    #[must_use]
     pub fn alpha_3(&self) -> &'static str {
         self.alpha_3
     }
 
     /// Returns the ISO 3166-1 numeric code.
+    #[must_use]
     pub fn numeric(&self) -> &'static str {
         self.numeric
     }
 
     /// Convert ISO 3166-1 alpha-2 country code to `ISO_3166` struct.
+    #[allow(clippy::too_many_lines)]
+    #[must_use]
     pub fn from_alpha_2(alpha_2: &str) -> Option<Self> {
         match alpha_2 {
             "AF" => Some(AFGHANISTAN),

--- a/src/iso/mod.rs
+++ b/src/iso/mod.rs
@@ -9,13 +9,19 @@
 
 //! ISO codes module.
 
+#[allow(clippy::module_name_repetitions)]
 pub use iso_10383::*;
+#[allow(clippy::module_name_repetitions)]
 pub use iso_3166::*;
+#[allow(clippy::module_name_repetitions)]
 pub use iso_4217::*;
 
 /// ISO 10383 market identifier codes module.
+#[allow(clippy::module_name_repetitions)]
 pub mod iso_10383;
 /// ISO 3166 country codes module.
+#[allow(clippy::module_name_repetitions)]
 pub mod iso_3166;
 /// ISO 4217 currency codes module.
+#[allow(clippy::module_name_repetitions)]
 pub mod iso_4217;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,13 @@
 //! I'm particularly interested in hearing from people with strong experience
 //! in implementing quantitative software in a professional setting.
 
+// Increase the amount of detail Clippy searches for.
+#![warn(clippy::pedantic)]
 // Strictly enforce documentation.
 #![forbid(missing_docs)]
+// When writing mathematical equations in documentation, Clippy suggests to
+// put backticks inside the LaTeX block. This suppresses that behavior.
+#![allow(clippy::doc_markdown)]
 // Allow snake case.
 // This is because much of this library is based on mathematics, so I
 // want to adhere to the standard mathematical notation.
@@ -23,6 +28,18 @@
 // There is no unsafe code currently, but for anyone to add any, it must be
 // documented with a SAFETY comment.
 #![forbid(clippy::undocumented_unsafe_blocks)]
+// I will add changes from clippy::nursery in coming commits.
+// #![warn(clippy::nursery)]
+// General miscellaneous clippy tunings.
+#![allow(
+    clippy::many_single_char_names,
+    // Temporary setting, as currently, `usize` is being used in places that
+    // don't deal with indexing.
+    clippy::cast_precision_loss,
+    // Awkward format strings. It seems to improve clarity to keep parameters
+    // grouped at the end.
+    clippy::uninlined_format_args
+)]
 
 pub mod autodiff;
 pub mod curves;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -73,23 +73,24 @@ macro_rules! plot_vector {
 
 #[cfg(test)]
 mod tests_plotters {
+    use std::f64::EPSILON as EPS;
 
     #[test]
     fn test_assert_approx_equal() {
-        assert_approx_equal!(1_f64, 1.0, 1e-10);
-        assert_approx_equal!(1_f64.exp(), std::f64::consts::E, 1e-10);
-        assert_approx_equal!(1_f64.ln(), 0.0, 1e-10);
-        assert_approx_equal!(1_f64.sin(), 0.8414709848078965, 1e-10);
-        assert_approx_equal!(1_f64.cos(), 0.5403023058681398, 1e-10);
-        assert_approx_equal!(1_f64.tan(), 1.5574077246549023, 1e-10);
-        assert_approx_equal!(1_f64.asin(), std::f64::consts::FRAC_PI_2, 1e-10);
-        assert_approx_equal!(1_f64.acos(), 0.0, 1e-10);
-        assert_approx_equal!(1_f64.atan(), std::f64::consts::FRAC_PI_4, 1e-10);
-        assert_approx_equal!(1_f64.sinh(), 1.1752011936438014, 1e-10);
-        assert_approx_equal!(1_f64.cosh(), 1.5430806348152437, 1e-10);
-        assert_approx_equal!(1_f64.tanh(), 0.7615941559557649, 1e-10);
-        assert_approx_equal!(1_f64.asinh(), 0.881373587019543, 1e-10);
-        assert_approx_equal!(1_f64.acosh(), 0.0, 1e-10);
+        assert_approx_equal!(1_f64, 1.0, EPS);
+        assert_approx_equal!(1_f64.exp(), std::f64::consts::E, EPS);
+        assert_approx_equal!(1_f64.ln(), 0.0, EPS);
+        assert_approx_equal!(1_f64.sin(), 0.841_470_984_807_896_5, EPS);
+        assert_approx_equal!(1_f64.cos(), 0.540_302_305_868_139_8, EPS);
+        assert_approx_equal!(1_f64.tan(), 1.557_407_724_654_902_3, EPS);
+        assert_approx_equal!(1_f64.asin(), std::f64::consts::FRAC_PI_2, EPS);
+        assert_approx_equal!(1_f64.acos(), 0.0, EPS);
+        assert_approx_equal!(1_f64.atan(), std::f64::consts::FRAC_PI_4, EPS);
+        assert_approx_equal!(1_f64.sinh(), 1.175_201_193_643_801_4, EPS);
+        assert_approx_equal!(1_f64.cosh(), 1.543_080_634_815_243_7, EPS);
+        assert_approx_equal!(1_f64.tanh(), 0.761_594_155_955_764_9, EPS);
+        assert_approx_equal!(1_f64.asinh(), 0.881_373_587_019_543, EPS);
+        assert_approx_equal!(1_f64.acosh(), 0.0, EPS);
     }
 
     #[test]

--- a/src/math/fft.rs
+++ b/src/math/fft.rs
@@ -18,6 +18,7 @@ use std::f64::consts::PI;
 
 /// Real FFT inplace,
 /// `x` length must be a power of 2
+#[allow(clippy::module_name_repetitions)]
 pub fn fft_real_inplace(x: &mut Vec<f64>) {
     check_vec_length(x);
 
@@ -26,6 +27,8 @@ pub fn fft_real_inplace(x: &mut Vec<f64>) {
 
 /// Real FFT and returns a new vector,
 /// `x` length must be a power of 2
+#[allow(clippy::module_name_repetitions)]
+#[must_use]
 pub fn fft_real(x: &Vec<f64>) -> Vec<f64> {
     check_vec_length(x);
 
@@ -38,6 +41,7 @@ pub fn fft_real(x: &Vec<f64>) -> Vec<f64> {
 
 /// Complex FFT inplace,
 /// `x` length must be a power of 2
+#[allow(clippy::module_name_repetitions)]
 pub fn fft_complex_inplace(x: &mut Vec<Complex<f64>>) {
     check_vec_length(x);
 
@@ -46,6 +50,8 @@ pub fn fft_complex_inplace(x: &mut Vec<Complex<f64>>) {
 
 /// Complex FFT and returns a new vector,
 /// `x` length must be a power of 2
+#[allow(clippy::module_name_repetitions)]
+#[must_use]
 pub fn fft_complex(x: &Vec<Complex<f64>>) -> Vec<Complex<f64>> {
     check_vec_length(x);
 
@@ -57,14 +63,16 @@ pub fn fft_complex(x: &Vec<Complex<f64>>) -> Vec<Complex<f64>> {
 }
 
 /// Helper function to check if a vector length is a power of 2
+#[must_use]
 pub fn is_valid_length<T>(x: &Vec<T>) -> bool {
     ((x.len() as f64).log2() % 1.0).abs() < 1e-10
 }
 
 fn check_vec_length<T>(x: &Vec<T>) {
-    if !is_valid_length(x) {
-        panic!("FFT can only handle vectors which length is a power of 2");
-    }
+    assert!(
+        is_valid_length(x),
+        "FFT can only handle vectors which length is a power of 2."
+    );
 }
 
 /// Real fourier transform in place
@@ -134,7 +142,7 @@ mod test {
     use super::*;
     use num_complex::Complex;
 
-    const SQRT_20: f64 = 4.472135955;
+    const SQRT_20: f64 = 4.472_135_955;
     const REAL_TEST_SEQUENCE: [f64; 4] = [-1.0, 2.0, 3.0, 0.0];
     const REAL_TEST_RESULT: [f64; 4] = [4.0, SQRT_20, 0.0, SQRT_20];
     const COMPLEX_TEST_SEQUENCE: [Complex<f64>; 4] = [
@@ -150,7 +158,7 @@ mod test {
         Complex::new(-4.0, 2.0),
     ];
 
-    fn assert_complex_vecs_almost_equal(x: Vec<Complex<f64>>, y: Vec<Complex<f64>>) {
+    fn assert_complex_vecs_almost_equal(x: &Vec<Complex<f64>>, y: &Vec<Complex<f64>>) {
         assert_eq!(x.len(), y.len());
 
         for (x_value, y_value) in x.iter().zip(y.iter()) {
@@ -158,7 +166,7 @@ mod test {
         }
     }
 
-    fn assert_real_vecs_almost_equal(x: Vec<f64>, y: Vec<f64>) {
+    fn assert_real_vecs_almost_equal(x: &Vec<f64>, y: &Vec<f64>) {
         assert_eq!(x.len(), y.len());
 
         for (x_value, y_value) in x.iter().zip(y.iter()) {
@@ -171,7 +179,7 @@ mod test {
         let mut test_vec = COMPLEX_TEST_SEQUENCE.to_vec();
         fft_complex_inplace(&mut test_vec);
 
-        assert_complex_vecs_almost_equal(test_vec, COMPLEX_TEST_RESULT.to_vec());
+        assert_complex_vecs_almost_equal(&test_vec, &COMPLEX_TEST_RESULT.to_vec());
     }
 
     #[test]
@@ -179,8 +187,8 @@ mod test {
         let test_vec = COMPLEX_TEST_SEQUENCE.to_vec();
         let result = fft_complex(&test_vec);
 
-        assert_complex_vecs_almost_equal(result, COMPLEX_TEST_RESULT.to_vec());
-        assert_complex_vecs_almost_equal(test_vec, COMPLEX_TEST_SEQUENCE.to_vec());
+        assert_complex_vecs_almost_equal(&result, &COMPLEX_TEST_RESULT.to_vec());
+        assert_complex_vecs_almost_equal(&test_vec, &COMPLEX_TEST_SEQUENCE.to_vec());
     }
 
     #[test]
@@ -188,7 +196,7 @@ mod test {
         let mut test_vec = REAL_TEST_SEQUENCE.to_vec();
         fft_real_inplace(&mut test_vec);
 
-        assert_real_vecs_almost_equal(test_vec, REAL_TEST_RESULT.to_vec());
+        assert_real_vecs_almost_equal(&test_vec, &REAL_TEST_RESULT.to_vec());
     }
 
     #[test]
@@ -196,12 +204,12 @@ mod test {
         let test_vec = REAL_TEST_SEQUENCE.to_vec();
         let result = fft_real(&test_vec);
 
-        assert_real_vecs_almost_equal(result, REAL_TEST_RESULT.to_vec());
-        assert_real_vecs_almost_equal(test_vec, REAL_TEST_SEQUENCE.to_vec());
+        assert_real_vecs_almost_equal(&result, &REAL_TEST_RESULT.to_vec());
+        assert_real_vecs_almost_equal(&test_vec, &REAL_TEST_SEQUENCE.to_vec());
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "FFT can only handle vectors which length is a power of 2.")]
     fn test_invalid_vec_length() {
         let test_vec = vec![0; 31];
         check_vec_length(&test_vec);

--- a/src/math/integration.rs
+++ b/src/math/integration.rs
@@ -69,7 +69,7 @@ where
     let mut integral = 0.0;
 
     for i in 0..100 {
-        integral += WEIGHTS[i] * f(ABSCISSAE[i])
+        integral += WEIGHTS[i] * f(ABSCISSAE[i]);
     }
 
     integral
@@ -298,6 +298,7 @@ pub const WEIGHTS: [f64; 100] = [
 mod tests_integration {
     use super::*;
     use crate::assert_approx_equal;
+    use std::f64::EPSILON as EPS;
 
     #[test]
     fn test_quadrature() {
@@ -307,6 +308,6 @@ mod tests_integration {
 
         let integral = integrate(f, 0.0, 5.0);
 
-        assert_approx_equal!(integral, 7.189119253631, 1e-8);
+        assert_approx_equal!(integral, 7.189_119_252_343_784, EPS);
     }
 }

--- a/src/math/interpolation.rs
+++ b/src/math/interpolation.rs
@@ -25,6 +25,7 @@ use time::OffsetDateTime;
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Interpolation method, either linear, quadratic, or cubic.
+#[allow(clippy::module_name_repetitions)]
 pub enum InterpolationMethod {
     /// Linear interpolation.
     Linear,
@@ -135,12 +136,15 @@ where
 mod tests_interpolation {
     use super::*;
 
+    use crate::assert_approx_equal;
+    use std::f64::EPSILON as EPS;
+
     #[test]
     fn test_lerp() {
-        assert_eq!(lerp(0.0, 1.0, 0.5), 0.5);
-        assert_eq!(lerp(0.0, 1.0, 0.0), 0.0);
-        assert_eq!(lerp(0.0, 1.0, 1.0), 1.0);
-        assert_eq!(lerp(0.0, 1.0, 2.0), 2.0);
-        assert_eq!(lerp(0.0, 1.0, -1.0), -1.0);
+        assert_approx_equal!(lerp(0.0, 1.0, 0.5), 0.5, EPS);
+        assert_approx_equal!(lerp(0.0, 1.0, 0.0), 0.0, EPS);
+        assert_approx_equal!(lerp(0.0, 1.0, 1.0), 1.0, EPS);
+        assert_approx_equal!(lerp(0.0, 1.0, 2.0), 2.0, EPS);
+        assert_approx_equal!(lerp(0.0, 1.0, -1.0), -1.0, EPS);
     }
 }

--- a/src/math/optimization/gradient_descent.rs
+++ b/src/math/optimization/gradient_descent.rs
@@ -72,7 +72,7 @@
 //! f(x,y) = (x^2 + y - 11)^2 + (x + y^2 - 7)^2
 //! $$
 
-use crate::autodiff::*;
+use crate::autodiff::{Accumulate, Gradient, Graph, Variable};
 use time::{Duration, Instant};
 // use ::log::{info, max_level, warn, Level};
 
@@ -96,6 +96,7 @@ pub struct GradientDescent {
 }
 
 /// Result of the gradient descent optimization.
+#[allow(clippy::module_name_repetitions)]
 pub struct GradientDescentResult {
     /// Minimizer of the function.
     pub minimizer: Vec<f64>,
@@ -112,6 +113,11 @@ pub struct GradientDescentResult {
 
 impl GradientDescent {
     /// Returns a new instance of the gradient descent optimizer.
+    ///
+    /// # Panics
+    ///
+    /// Panics if tolerance is not positive.
+    #[must_use]
     pub fn new(learning_rate: f64, max_iterations: usize, tolerance: Option<f64>) -> Self {
         if tolerance.is_some() {
             assert!(tolerance.unwrap() > 0.0);
@@ -214,7 +220,7 @@ impl GradientDescent {
 #[cfg(test)]
 mod test_gradient_descent {
     use super::*;
-    use crate::autodiff::Variable;
+    use crate::autodiff::{Powf, Variable};
 
     // Test the creation of a new GradientDescent optimizer.
     #[test]
@@ -251,7 +257,7 @@ mod test_gradient_descent {
         }
 
         // GradientDescent::new(learning_rate, max_iterations, tolerance)
-        let gd = GradientDescent::new(0.1, 1000, Some(0.000001));
+        let gd = GradientDescent::new(0.1, 1000, Some(0.000_001));
         let result = gd.optimize(f, &[10.0], false);
 
         println!("Minimum: {:?}", result.minimum);
@@ -275,7 +281,7 @@ mod test_gradient_descent {
         }
 
         // GradientDescent::new(learning_rate, max_iterations, tolerance)
-        let gd = GradientDescent::new(0.1, 1000, Some(0.000001));
+        let gd = GradientDescent::new(0.1, 1000, Some(0.000_001));
         let result = gd.optimize(f, &[5.0, 5.0], false);
 
         println!("Minimum: {:?}", result.minimum);
@@ -298,7 +304,7 @@ mod test_gradient_descent {
         }
 
         // GradientDescent::new(learning_rate, max_iterations, tolerance)
-        let gd = GradientDescent::new(0.001, 10000, Some(0.000001));
+        let gd = GradientDescent::new(0.001, 10000, Some(0.000_001));
         let result = gd.optimize(f, &[0.0, 5.0], false);
 
         println!("Minimum: {:?}", result.minimum);

--- a/src/math/risk_reward.rs
+++ b/src/math/risk_reward.rs
@@ -43,6 +43,7 @@ impl PortfolioMeasures {
     /// * `r_p` is the average return of the portfolio.
     /// * `r` is the risk-free return over the same period.
     /// * `beta_p` is the beta of the portfolio.
+    #[must_use]
     pub fn treynors_ratio(&self) -> f64 {
         (self.r_p - self.r) / self.beta_p
     }
@@ -56,6 +57,7 @@ impl PortfolioMeasures {
     /// * `r_p` is the average return of the portfolio.
     /// * `r` is the risk-free return over the same period.
     /// * `sigma_p` is the standard deviation of the portfolio returns.
+    #[must_use]
     pub fn sharpe_ratio(&self) -> f64 {
         (self.r_p - self.r) / self.sigma_p
     }
@@ -69,6 +71,7 @@ impl PortfolioMeasures {
     /// * `r_p` is the average return of the portfolio.
     /// * `r` is the risk-free return over the same period.
     /// * `sigma_down` is the *downside* standard deviation of the portfolio returns, also known as semistandard deviation.
+    #[must_use]
     pub fn sortino_ratio(&self) -> f64 {
         (self.r_p - self.r) / self.sigma_down
     }
@@ -82,6 +85,7 @@ impl PortfolioMeasures {
     /// * `r_p` is the average return of the portfolio.
     /// * `r` is the risk-free return over the same period.
     /// * `ss_drawdowns` is the sum of the squared drawdowns.
+    #[must_use]
     pub fn burke_ratio(&self, drawdowns: &[f64]) -> f64 {
         let ss_drawdowns = drawdowns.iter().map(|x| x.powi(2)).sum::<f64>();
 
@@ -96,6 +100,7 @@ impl PortfolioMeasures {
     ///
     /// * `r_p` is the average return of the portfolio.
     /// * `var` is the Value-at-Risk.
+    #[must_use]
     pub fn return_on_var(&self) -> f64 {
         self.r_p / self.var
     }
@@ -110,6 +115,7 @@ impl PortfolioMeasures {
     /// * `r` is the risk-free return over the same period.
     /// * `beta_p` is the beta of the portfolio.
     /// * `r_m` is the expected market return.
+    #[must_use]
     pub fn jensens_alpha(&self) -> f64 {
         self.r_p - (self.r + self.beta_p * (self.r_m - self.r))
     }
@@ -123,6 +129,8 @@ impl PortfolioMeasures {
 mod tests_risk_reward {
     use super::*;
 
+    use std::f64::EPSILON as EPS;
+
     static PORTFOLIO: PortfolioMeasures = PortfolioMeasures {
         r_p: 0.12,
         r: 0.05,
@@ -135,39 +143,41 @@ mod tests_risk_reward {
 
     #[test]
     fn test_treynors_ratio() {
-        assert_eq!(PORTFOLIO.treynors_ratio(), (0.12 - 0.05) / 1.2);
+        assert_approx_equal!(PORTFOLIO.treynors_ratio(), (0.12 - 0.05) / 1.2, EPS);
     }
 
     #[test]
     fn test_sharpe_ratio() {
-        assert_eq!(PORTFOLIO.sharpe_ratio(), (0.12 - 0.05) / 0.2);
+        assert_approx_equal!(PORTFOLIO.sharpe_ratio(), (0.12 - 0.05) / 0.2, EPS);
     }
 
     #[test]
     fn test_sortino_ratio() {
-        assert_eq!(PORTFOLIO.sortino_ratio(), (0.12 - 0.05) / 0.1);
+        assert_approx_equal!(PORTFOLIO.sortino_ratio(), (0.12 - 0.05) / 0.1, EPS);
     }
 
     #[test]
     fn test_burke_ratio() {
         let drawdowns = vec![0.05, 0.10, 0.20];
         let ss_drawdowns = drawdowns.iter().map(|x| x * x).sum::<f64>();
-        assert_eq!(
+        assert_approx_equal!(
             PORTFOLIO.burke_ratio(&drawdowns),
-            (0.12 - 0.05) / ss_drawdowns
+            (0.12 - 0.05) / ss_drawdowns,
+            EPS
         );
     }
 
     #[test]
     fn test_return_on_var() {
-        assert_eq!(PORTFOLIO.return_on_var(), 0.12 / 0.15);
+        assert_approx_equal!(PORTFOLIO.return_on_var(), 0.12 / 0.15, EPS);
     }
 
     #[test]
     fn test_jensens_alpha() {
-        assert_eq!(
+        assert_approx_equal!(
             PORTFOLIO.jensens_alpha(),
-            0.12 - (0.05 + 1.2 * (0.1 - 0.05))
+            0.12 - (0.05 + 1.2 * (0.1 - 0.05)),
+            EPS
         );
     }
 }

--- a/src/ml/activations.rs
+++ b/src/ml/activations.rs
@@ -14,24 +14,32 @@ use statrs::function::erf;
 /// Activation functions.
 pub trait ActivationFunction {
     /// Applies the sigmoid function to the input.
+    #[must_use]
     fn sigmoid(&self) -> Self;
     /// Applies the identity function to the input.
+    #[must_use]
     fn identity(&self) -> Self;
     /// Applies the logistic function to the input.
     ///
     /// Note (for logistic regression):
     /// sigmoid(x) = 1 / (1 + exp(-x)) = exp(x) / (exp(x) + 1)    
     /// mu(x) = E[Y | X] = P(Y = 1 | X) = sigmoid(w^T x)
+    #[must_use]
     fn logistic(&self) -> Self;
     /// Applies the rectified linear unit function to the input.
+    #[must_use]
     fn relu(&self) -> Self;
     /// Applies the gaussian error linear unit function to the input.
+    #[must_use]
     fn gelu(&self) -> Self;
     /// Applies the hyperbolic tangent function to the input.
+    #[must_use]
     fn tanh(&self) -> Self;
     /// Applies the softplus function to the input.
+    #[must_use]
     fn softplus(&self) -> Self;
     /// Applies the gaussian function to the input.
+    #[must_use]
     fn gaussian(&self) -> Self;
 }
 
@@ -151,7 +159,7 @@ impl ActivationFunction for DVector<f64> {
 
     #[inline]
     fn tanh(&self) -> Self {
-        self.map(|x| x.tanh())
+        self.map(f64::tanh)
     }
 
     #[inline]

--- a/src/ml/linear_regression.rs
+++ b/src/ml/linear_regression.rs
@@ -23,6 +23,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 
 ///For better error handling
+#[allow(clippy::module_name_repetitions)]
 pub enum LinearRegressionError {
     /// failed to invert matrix
     #[error("Matrix inversion failed")]
@@ -38,6 +39,7 @@ pub enum LinearRegressionError {
 }
 
 /// Struct to hold the input data for a linear regression.
+#[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Debug)]
 pub struct LinearRegressionInput<T> {
     /// The input data matrix, also known as the design matrix.
@@ -49,6 +51,7 @@ pub struct LinearRegressionInput<T> {
 }
 
 /// Struct to hold the output data for a linear regression.
+#[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Debug)]
 pub struct LinearRegressionOutput<T> {
     /// The intercept of the linear regression,
@@ -60,6 +63,7 @@ pub struct LinearRegressionOutput<T> {
 }
 
 /// Enum for type of matrix decomposition used.
+#[derive(Copy, Clone)]
 pub enum Decomposition {
     /// No decomposition to be used.
     /// Naive implementation of linear regression.
@@ -85,6 +89,7 @@ pub enum Decomposition {
 
 impl LinearRegressionInput<f64> {
     /// Create a new `LinearRegressionInput` struct.
+    #[must_use]
     pub fn new(x: DMatrix<f64>, y: DVector<f64>) -> Self {
         Self { x, y }
     }
@@ -191,6 +196,8 @@ mod tests_linear_regression {
     use crate::assert_approx_equal;
     use std::time::Instant;
 
+    use std::f64::EPSILON as EPS;
+
     #[test]
     fn test_linear_regression() -> Result<(), LinearRegressionError> {
         // TEST DATA GENERATED FROM THE FOLLOWING R CODE:
@@ -211,24 +218,24 @@ mod tests_linear_regression {
         let x_train = DMatrix::from_row_slice(
             4, // rows
             3, // columns
-            &[-0.083784355, -0.63348570, -0.39926660, 
-              -0.982943745,  1.09079746, -0.46812305,
-              -1.875067321, -0.91372727,  0.32696208,
-              -0.186144661,  1.00163971, -0.41274690],
+            &[-0.083_784_355, -0.633_485_70, -0.399_266_60,
+              -0.982_943_745,  1.090_797_46, -0.468_123_05,
+              -1.875_067_321, -0.913_727_27,  0.326_962_08,
+              -0.186_144_661,  1.001_639_71, -0.412_746_90],
         );
 
         #[rustfmt::skip]
         let x_test = DMatrix::from_row_slice(
             4, // rows
             3, // columns
-            &[0.56203647, 0.59584645, -0.41165301, 
-              0.66335826, 0.45209183, -0.29432715,
-             -0.60289728, 0.89674396, 1.21857396, 
-              0.69837769, 0.57221651, 0.24411143],
+            &[0.562_036_47, 0.595_846_45, -0.411_653_01,
+              0.663_358_26, 0.452_091_83, -0.294_327_15,
+             -0.602_897_28, 0.896_743_96, 1.218_573_96,
+              0.698_377_69, 0.572_216_51, 0.244_111_43],
         );
 
         let response =
-            DVector::from_row_slice(&[-0.44515196, -1.84780364, -0.62882531, -0.86108069]);
+            DVector::from_row_slice(&[-0.445_151_96, -1.847_803_64, -0.628_825_31, -0.861_080_69]);
 
         // Fit the model to the training data.
         let input = LinearRegressionInput {
@@ -264,14 +271,19 @@ mod tests_linear_regression {
         let preds = output.predict(x_test)?;
 
         // Check intercept.
-        assert_approx_equal!(output.intercept, 0.45326734, 1e-6);
+        assert_approx_equal!(output.intercept, 0.453_267_356_085_818_9, EPS);
 
         // Check coefficients.
         for (i, coefficient) in output.coefficients.iter().enumerate() {
             assert_approx_equal!(
                 coefficient,
-                &[0.45326734, 1.05986612, -0.16909348, 2.29605328][i],
-                1e-6
+                &[
+                    0.453_267_356_085_818_9,
+                    1.059_866_132_317_468_5,
+                    -0.169_093_464_601_759_45,
+                    2.296_053_332_765_449_5
+                ][i],
+                EPS
             );
         }
 
@@ -279,8 +291,13 @@ mod tests_linear_regression {
         for (i, pred) in preds.iter().enumerate() {
             assert_approx_equal!(
                 pred,
-                &[0.0030197504, 0.4041016953, 2.4605541127, 1.6571889522][i],
-                1e-3
+                &[
+                    0.003_019_769_611_493_972,
+                    0.404_101_701_919_158_5,
+                    2.460_554_206_769_587_4,
+                    1.657_189_007_522_339_4
+                ][i],
+                EPS
             );
         }
         Ok(())

--- a/src/money/currency.rs
+++ b/src/money/currency.rs
@@ -14,7 +14,7 @@
 //! same underlying currency.
 
 use crate::instruments::Instrument;
-use crate::iso::*;
+use crate::iso::ISO_4217;
 use std::fmt::{self, Formatter};
 use time::OffsetDateTime;
 
@@ -128,6 +128,7 @@ impl fmt::Display for ISO_4217 {
 
 impl Currency {
     /// Create a new currency.
+    #[must_use]
     pub fn new(
         name: &'static str,
         symbol: &'static str,
@@ -145,26 +146,31 @@ impl Currency {
     }
 
     /// Get the currency name.
+    #[must_use]
     pub fn name(&self) -> &str {
         self.name
     }
 
     /// Get the currency symbol.
+    #[must_use]
     pub fn symbol(&self) -> &str {
         self.symbol
     }
 
     /// Get the currency code.
+    #[must_use]
     pub fn code(&self) -> ISO_4217 {
         self.code
     }
 
     /// Get the minor unit.
+    #[must_use]
     pub fn minor(&self) -> usize {
         self.minor
     }
 
     /// Get the fractions per unit.
+    #[must_use]
     pub fn fractions(&self) -> usize {
         self.fractions
     }
@@ -172,16 +178,19 @@ impl Currency {
 
 impl Money {
     /// Create a new money instance.
+    #[must_use]
     pub fn new(currency: Currency, amount: f64) -> Self {
         Self { currency, amount }
     }
 
     /// Get the currency.
+    #[must_use]
     pub fn currency(&self) -> Currency {
         self.currency
     }
 
     /// Get the amount.
+    #[must_use]
     pub fn amount(&self) -> f64 {
         self.amount
     }
@@ -189,6 +198,7 @@ impl Money {
 
 impl ISO_4217 {
     /// Create a new ISO 4217 code.
+    #[must_use]
     pub fn new(alphabetic: &'static str, numeric: &'static str) -> Self {
         Self {
             alphabetic,
@@ -197,11 +207,13 @@ impl ISO_4217 {
     }
 
     /// Get the ISO 4217 alphabetic code.
+    #[must_use]
     pub fn alphabetic(&self) -> &str {
         self.alphabetic
     }
 
     /// Get the ISO 4217 numeric code.
+    #[must_use]
     pub fn numeric(&self) -> &str {
         self.numeric
     }
@@ -275,6 +287,9 @@ impl std::ops::Div for Money {
 mod test_currencies {
     use super::*;
 
+    use crate::assert_approx_equal;
+    use std::f64::EPSILON as EPS;
+
     // Setup some example currencies and money for testing
     const USD: Currency = Currency {
         name: "United States Dollar",
@@ -344,7 +359,7 @@ mod test_currencies {
         let money1 = Money::new(USD, 20.5);
         let money2 = Money::new(USD, 10.5);
         let result = money1 + money2;
-        assert_eq!(result.amount(), 31.0);
+        assert_approx_equal!(result.amount(), 31.0, EPS);
     }
 
     #[test]
@@ -360,7 +375,7 @@ mod test_currencies {
         let money1 = Money::new(USD, 20.5);
         let money2 = Money::new(USD, 10.5);
         let result = money1 - money2;
-        assert_eq!(result.amount(), 10.0);
+        assert_approx_equal!(result.amount(), 10.0, EPS);
     }
 
     #[test]
@@ -376,7 +391,7 @@ mod test_currencies {
         let money1 = Money::new(USD, 20.0);
         let money2 = Money::new(USD, 2.0);
         let result = money1 * money2;
-        assert_eq!(result.amount(), 40.0);
+        assert_approx_equal!(result.amount(), 40.0, EPS);
     }
 
     #[test]
@@ -392,7 +407,7 @@ mod test_currencies {
         let money1 = Money::new(USD, 40.0);
         let money2 = Money::new(USD, 2.0);
         let result = money1 / money2;
-        assert_eq!(result.amount(), 20.0);
+        assert_approx_equal!(result.amount(), 20.0, EPS);
     }
 
     #[test]

--- a/src/money/exchange.rs
+++ b/src/money/exchange.rs
@@ -9,7 +9,7 @@
 
 // use crate::RustQuantError;
 // use crate::money::{iso_currencies::*, Currency, Money};
-use crate::money::*;
+use crate::money::{Currency, Money};
 use std::collections::HashMap;
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -26,7 +26,8 @@ pub struct Exchange {
     pub rates: HashMap<String, ExchangeRate>,
 }
 
-/// ExchangeRate struct to hold exchange rate information.
+/// `ExchangeRate` struct to hold exchange rate information.
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Copy)]
 pub struct ExchangeRate {
     /// From currency
@@ -51,13 +52,14 @@ impl Exchange {
     /// let exchange = Exchange::new();
     /// ```
     ///
+    #[must_use]
     pub fn new() -> Self {
         Self {
             rates: HashMap::new(),
         }
     }
 
-    /// Adds a new ExchangeRate to the Exchange.
+    /// Adds a new `ExchangeRate` to the Exchange.
     ///
     /// # Example
     /// ```
@@ -80,7 +82,7 @@ impl Exchange {
         self.rates.insert(key, rate);
     }
 
-    /// Retrieves an ExchangeRate from the Exchange.
+    /// Retrieves an `ExchangeRate` from the Exchange.
     ///
     /// # Example
     /// ```
@@ -96,11 +98,12 @@ impl Exchange {
     ///
     /// let retrieved_usd_to_eur = exchange.get_rate(&USD, &EUR).expect("Rate not found");
     /// assert_eq!(retrieved_usd_to_eur.rate, 0.85);
-    ///     
+    ///
     /// let retrieved_eur_to_usd = exchange.get_rate(&EUR, &USD).expect("Rate not found");
     /// assert_eq!(retrieved_eur_to_usd.rate, 1.18);
     /// ```
     ///
+    #[must_use]
     pub fn get_rate(
         &self,
         from_currency: &Currency,
@@ -114,26 +117,27 @@ impl Exchange {
     }
 
     /// Convert money from one currency to another using the exchange rate in the Exchange.
-    /// It panics if the conversion rate is not found or if the money's currency doesn't match with from_currency.
+    /// It panics if the conversion rate is not found or if the money's currency doesn't match with `from_currency`.
     ///
     /// # Example
     /// ```
     /// use RustQuant::money::*;
-    ///     
+    ///
     /// let mut exchange = Exchange::new();
     ///
     /// let usd_to_eur = ExchangeRate::new(USD, EUR, 0.85); // USD to EUR
     /// let eur_to_usd = ExchangeRate::new(EUR, USD, 1.18); // EUR to USD
-    ///     
+    ///
     /// exchange.add_rate(usd_to_eur);
     /// exchange.add_rate(eur_to_usd);
-    ///     
+    ///
     /// let usd_100 = Money::new(USD, 100.0); // 100 USD
     /// let eur_85 = exchange.convert(usd_100, EUR); // Should be 85 EUR
     ///
     /// assert_eq!(eur_85.currency, EUR);
     /// assert_eq!(eur_85.amount, 85.0);
     /// ```
+    #[must_use]
     pub fn convert(&self, money: Money, to_currency: Currency) -> Money {
         let rate = self
             .get_rate(&money.currency, &to_currency)
@@ -149,6 +153,7 @@ impl Exchange {
 
 impl ExchangeRate {
     /// Create a new exchange rate.
+    #[must_use]
     pub fn new(from_currency: Currency, to_currency: Currency, rate: f64) -> Self {
         Self {
             from_currency,
@@ -158,7 +163,7 @@ impl ExchangeRate {
     }
 
     /// Convert money from one currency to another using this exchange rate.
-    /// It panics if the money's currency doesn't match with from_currency.
+    /// It panics if the money's currency doesn't match with `from_currency`.
     ///
     /// # Example
     /// ```
@@ -174,7 +179,7 @@ impl ExchangeRate {
     /// assert_eq!(eur.currency, EUR);
     /// ```
     ///
-    /// It panics if the money's currency doesn't match with from_currency.
+    /// It panics if the money's currency doesn't match with `from_currency`.
     ///
     /// ```should_panic
     /// use RustQuant::money::*;
@@ -184,6 +189,7 @@ impl ExchangeRate {
     ///
     /// eur_usd.convert(usd);  // This will panic
     /// ```
+    #[must_use]
     pub fn convert(&self, money: Money) -> Money {
         if money.currency == self.from_currency {
             let new_amount = money.amount * self.rate;
@@ -205,6 +211,10 @@ impl ExchangeRate {
 mod test_exchange_rate {
     use super::*;
     use crate::iso::*;
+
+    use crate::assert_approx_equal;
+    use crate::money::{EUR, USD};
+    use std::f64::EPSILON as EPS;
 
     #[test]
     fn test_conversion() {
@@ -230,7 +240,7 @@ mod test_exchange_rate {
 
         // Verify the conversion
         assert_eq!(eur_85.currency, eur);
-        assert_eq!(eur_85.amount, 85_f64);
+        assert_approx_equal!(eur_85.amount, 85.0, EPS);
     }
 
     #[test]
@@ -244,10 +254,10 @@ mod test_exchange_rate {
         exchange.add_rate(eur_to_usd);
 
         let retrieved_usd_to_eur = exchange.get_rate(&USD, &EUR).expect("Rate not found");
-        assert_eq!(retrieved_usd_to_eur.rate, 0.85);
+        assert_approx_equal!(retrieved_usd_to_eur.rate, 0.85, EPS);
 
         let retrieved_eur_to_usd = exchange.get_rate(&EUR, &USD).expect("Rate not found");
-        assert_eq!(retrieved_eur_to_usd.rate, 1.18);
+        assert_approx_equal!(retrieved_eur_to_usd.rate, 1.18, EPS);
     }
 
     #[test]
@@ -264,6 +274,6 @@ mod test_exchange_rate {
         let eur_85 = exchange.convert(usd_100, EUR); // Should be 85 EUR
 
         assert_eq!(eur_85.currency, EUR);
-        assert_eq!(eur_85.amount, 85.0);
+        assert_approx_equal!(eur_85.amount, 85.0, EPS);
     }
 }

--- a/src/money/legs.rs
+++ b/src/money/legs.rs
@@ -29,11 +29,13 @@ pub struct Leg<C: Cashflow> {
 
 impl<C: Cashflow> Leg<C> {
     /// Creates a new leg with given cashflows.
+    #[must_use]
     pub fn new(cashflows: Vec<C>) -> Self {
         Self { cashflows }
     }
 
     /// Returns the number of cashflows in the leg.
+    #[must_use]
     pub fn size(&self) -> usize {
         self.cashflows.len()
     }
@@ -52,21 +54,25 @@ impl<C: Cashflow> Leg<C> {
     }
 
     /// Returns a slice of all the cashflows in the leg.
+    #[must_use]
     pub fn cashflows(&self) -> &[C] {
         &self.cashflows
     }
 
     /// Returns the start date of the leg.
+    #[must_use]
     pub fn start_date(&self) -> Option<OffsetDateTime> {
-        self.cashflows.iter().map(|x| x.date()).min()
+        self.cashflows.iter().map(Cashflow::date).min()
     }
 
     /// Returns the end date of the leg.
+    #[must_use]
     pub fn end_date(&self) -> Option<OffsetDateTime> {
-        self.cashflows.iter().map(|x| x.date()).max()
+        self.cashflows.iter().map(Cashflow::date).max()
     }
 
     /// Returns true if the leg is active at the given date.
+    #[must_use]
     pub fn is_active(&self, current_date: OffsetDateTime) -> bool {
         match (self.start_date(), self.end_date()) {
             (Some(start), Some(end)) => current_date >= start && current_date <= end,
@@ -84,6 +90,9 @@ mod tests_legs {
     use super::super::SimpleCashflow;
     use super::*;
     use time::Duration;
+
+    use crate::assert_approx_equal;
+    use std::f64::EPSILON as EPS;
 
     // Utility function to generate a simple leg for testing.
     fn generate_simple_leg(now: OffsetDateTime) -> Leg<SimpleCashflow> {
@@ -111,7 +120,7 @@ mod tests_legs {
 
         // Discount function that reduces value by 10%.
         let df = |_| 0.9;
-        assert_eq!(leg.npv(df), 540.0);
+        assert_approx_equal!(leg.npv(df), 540.0, EPS);
     }
 
     // Test to verify the `add_cashflow` method.
@@ -122,9 +131,10 @@ mod tests_legs {
         let new_cashflow = SimpleCashflow::new(400.0, now + Duration::days(90));
         leg.add_cashflow(new_cashflow.clone());
         assert_eq!(leg.size(), 4);
-        assert_eq!(
+        assert_approx_equal!(
             leg.cashflows().last().unwrap().amount(),
-            new_cashflow.amount()
+            new_cashflow.amount(),
+            EPS
         );
     }
 

--- a/src/money/quotes.rs
+++ b/src/money/quotes.rs
@@ -22,6 +22,7 @@ pub struct SimpleQuote {
 
 impl SimpleQuote {
     /// Create a new simple quote.
+    #[must_use]
     pub fn new(value: Option<f64>) -> Self {
         SimpleQuote { value }
     }

--- a/src/portfolio.rs
+++ b/src/portfolio.rs
@@ -158,19 +158,19 @@ where
     I: Instrument,
 {
     /// Create a new portfolio.
-    pub fn new(positions: HashMap<String, Position<I>>) -> Self {
+    #[must_use]
+    pub const fn new(positions: HashMap<String, Position<I>>) -> Self {
         Self { positions }
     }
 
     /// Returns the value of the portfolio.
+    #[must_use]
     pub fn value(&self) -> f64 {
-        self.positions
-            .values()
-            .map(|position| position.value())
-            .sum()
+        self.positions.values().map(Position::value).sum()
     }
 
     /// Returns the cost of the portfolio.
+    #[must_use]
     pub fn cost(&self) -> f64 {
         self.positions
             .values()
@@ -179,14 +179,16 @@ where
     }
 
     /// Returns the profit (or loss) of the portfolio.
+    #[must_use]
     pub fn profit(&self) -> f64 {
-        self.positions
-            .values()
-            .map(|position| position.profit())
-            .sum()
+        self.positions.values().map(Position::profit).sum()
     }
 
     /// Update the price of a position in the portfolio.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `instrument_name` not found in the portfolio
     pub fn update_price(&mut self, instrument_name: &str, new_price: f64) {
         self.positions
             .get_mut(instrument_name)
@@ -195,6 +197,10 @@ where
     }
 
     /// Update the quantity of a position in the portfolio.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `instrument_name` not found in the portfolio
     pub fn update_quantity(&mut self, instrument_name: &str, new_quantity: u64) {
         self.positions
             .get_mut(instrument_name)

--- a/src/statistics/distributions/binomial.rs
+++ b/src/statistics/distributions/binomial.rs
@@ -44,6 +44,11 @@ impl Binomial {
     ///
     /// assert_eq!(binomial.mean(), 2.0);
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if probability is not in $[0, 1]$.
+    #[must_use]
     pub fn new(trials: usize, probability: f64) -> Self {
         assert!((0.0..=1.0).contains(&probability));
 
@@ -127,7 +132,7 @@ impl Distribution for Binomial {
     /// assert_approx_equal!(binomial.cdf(3.0), 0.9129600, 1e-7);
     /// ```
     fn cdf(&self, k: f64) -> f64 {
-        statrs::function::beta::beta_reg((self.n - k as usize) as f64, 1. + k, 1. - self.p)
+        statrs::function::beta::beta_reg((self.n - k as usize) as f64, 1_f64 + k, 1_f64 - self.p)
     }
 
     /// Inverse distribution (quantile) function of the Binomial distribution.
@@ -302,6 +307,8 @@ mod tests_binomial_distribution {
     use super::*;
     use crate::assert_approx_equal;
 
+    use std::f64::EPSILON as EPS;
+
     #[test]
     fn test_binomial_distribution() {
         // n = 2 trials, p = 0.5 probability
@@ -309,18 +316,18 @@ mod tests_binomial_distribution {
 
         // Characteristic function
         let cf = dist.cf(1.0);
-        assert_approx_equal!(cf.re, 0.41611444379, 1e-10);
-        assert_approx_equal!(cf.im, 0.64805984911, 1e-10);
+        assert_approx_equal!(cf.re, 0.416_114_443_797_284_35, EPS);
+        assert_approx_equal!(cf.im, 0.648_059_849_110_368_7, EPS);
 
         // Probability mass function
         // k = 1 successes.
         let pmf = dist.pmf(1.);
-        assert_approx_equal!(pmf, 0.5, 1e-10);
+        assert_approx_equal!(pmf, 0.5, EPS);
 
         // Distribution function
         // k = 1 successes.
         let cdf = dist.cdf(1.);
-        assert_approx_equal!(cdf, 0.75, 1e-10);
+        assert_approx_equal!(cdf, 0.749_999_999_999_999_1, EPS);
     }
 
     #[test]
@@ -329,24 +336,24 @@ mod tests_binomial_distribution {
 
         // Characteristic function
         let cf = binomial.cf(1.0);
-        assert_approx_equal!(cf.re, -0.2014034, 1e-6);
-        assert_approx_equal!(cf.im, 0.4969347, 1e-6);
+        assert_approx_equal!(cf.re, -0.201_403_389_549_595_36, EPS);
+        assert_approx_equal!(cf.im, 0.496_934_703_617_956_4, EPS);
 
         // Probability mass function
         let pmf = binomial.pmf(3.0);
-        assert_approx_equal!(pmf, 0.2304, 1e-4);
+        assert_approx_equal!(pmf, 0.2304, EPS);
 
         // Distribution function
         let cdf = binomial.cdf(3.0);
-        assert_approx_equal!(cdf, 0.91296, 1e-5);
+        assert_approx_equal!(cdf, 0.91296, EPS);
 
-        assert_eq!(binomial.mean(), 2.0);
-        assert_eq!(binomial.median(), 2.0);
-        assert_eq!(binomial.mode(), 2.0);
+        assert_approx_equal!(binomial.mean(), 2.0, EPS);
+        assert_approx_equal!(binomial.median(), 2.0, EPS);
+        assert_approx_equal!(binomial.mode(), 2.0, EPS);
         assert_approx_equal!(binomial.variance(), 1.2, 1e-6);
-        assert_approx_equal!(binomial.skewness(), 0.182574, 1e-6);
-        assert_approx_equal!(binomial.kurtosis(), -0.366667, 1e-6);
-        assert_approx_equal!(binomial.entropy(), 1.510099, 1e-6);
-        assert_approx_equal!(binomial.mgf(1.0), 13.67659, 1e-5);
+        assert_approx_equal!(binomial.skewness(), 0.182_574_185_835_055_33, EPS);
+        assert_approx_equal!(binomial.kurtosis(), -0.366_666_666_666_666_8, EPS);
+        assert_approx_equal!(binomial.entropy(), 1.510_099_311_601_65, EPS);
+        assert_approx_equal!(binomial.mgf(1.0), 13.676_592_816_585_314, EPS);
     }
 }

--- a/src/statistics/distributions/chi_squared.rs
+++ b/src/statistics/distributions/chi_squared.rs
@@ -42,6 +42,11 @@ impl ChiSquared {
     ///
     /// assert_eq!(dist.mean(), 1.0);
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if `k` is not positive.
+    #[must_use]
     pub fn new(k: usize) -> Self {
         assert!(k > 0);
 
@@ -312,8 +317,8 @@ mod tests {
         let dist: ChiSquared = ChiSquared::new(1);
 
         let cf = dist.cf(1.0);
-        assert_approx_equal!(cf.re, 0.5688645, 1e-7);
-        assert_approx_equal!(cf.im, 0.3515776, 1e-7);
+        assert_approx_equal!(cf.re, 0.568_864_5, 1e-7);
+        assert_approx_equal!(cf.im, 0.351_577_6, 1e-7);
     }
 
     #[test]
@@ -321,11 +326,11 @@ mod tests {
         let dist: ChiSquared = ChiSquared::new(1);
 
         // Values computed using R
-        assert_approx_equal!(dist.pdf(1.0), 0.24197072, 1e-8);
-        assert_approx_equal!(dist.pdf(2.0), 0.10377687, 1e-8);
-        assert_approx_equal!(dist.pdf(3.0), 0.05139344, 1e-8);
-        assert_approx_equal!(dist.pdf(4.0), 0.02699548, 1e-8);
-        assert_approx_equal!(dist.pdf(5.0), 0.01464498, 1e-8);
+        assert_approx_equal!(dist.pdf(1.0), 0.241_970_72, 1e-8);
+        assert_approx_equal!(dist.pdf(2.0), 0.103_776_87, 1e-8);
+        assert_approx_equal!(dist.pdf(3.0), 0.051_393_44, 1e-8);
+        assert_approx_equal!(dist.pdf(4.0), 0.026_995_48, 1e-8);
+        assert_approx_equal!(dist.pdf(5.0), 0.014_644_98, 1e-8);
     }
 
     #[test]
@@ -333,10 +338,10 @@ mod tests {
         let dist: ChiSquared = ChiSquared::new(1);
 
         // Values computed using R
-        assert_approx_equal!(dist.cdf(1.0), 0.6826895, 1e-7);
-        assert_approx_equal!(dist.cdf(2.0), 0.8427008, 1e-7);
-        assert_approx_equal!(dist.cdf(3.0), 0.9167355, 1e-7);
-        assert_approx_equal!(dist.cdf(4.0), 0.9544997, 1e-7);
-        assert_approx_equal!(dist.cdf(5.0), 0.9746527, 1e-7);
+        assert_approx_equal!(dist.cdf(1.0), 0.682_689_5, 1e-7);
+        assert_approx_equal!(dist.cdf(2.0), 0.842_700_8, 1e-7);
+        assert_approx_equal!(dist.cdf(3.0), 0.916_735_5, 1e-7);
+        assert_approx_equal!(dist.cdf(4.0), 0.954_499_7, 1e-7);
+        assert_approx_equal!(dist.cdf(5.0), 0.974_652_7, 1e-7);
     }
 }

--- a/src/statistics/distributions/distribution.rs
+++ b/src/statistics/distributions/distribution.rs
@@ -15,6 +15,7 @@ use thiserror::Error;
 pub const i: Complex<f64> = Complex { re: 0.0, im: 1.0 };
 
 /// Distribution class/type.
+#[allow(clippy::module_name_repetitions)]
 pub enum DistributionClass {
     /// Discrete distribution.
     Discrete,
@@ -24,6 +25,7 @@ pub enum DistributionClass {
 
 /// Distribution error type.
 #[derive(Debug, Error)]
+#[allow(clippy::module_name_repetitions)]
 pub enum DistributionError {
     /// Error variant from constructing Bernoulli distribution.
     #[error("{0}")]

--- a/src/statistics/distributions/exponential.rs
+++ b/src/statistics/distributions/exponential.rs
@@ -26,6 +26,11 @@ pub struct Exponential {
 
 impl Exponential {
     /// New instance of a Exponential distribution.
+    ///
+    /// # Panics
+    ///
+    /// Panics if lambda is greater than 0.0
+    #[must_use]
     pub fn new(lambda: f64) -> Self {
         assert!(lambda > 0.0);
 
@@ -226,14 +231,16 @@ mod tests {
     use super::*;
     use crate::assert_approx_equal;
 
+    use std::f64::EPSILON as EPS;
+
     #[test]
     fn test_exponential_characteristic_function() {
         let dist: Exponential = Exponential::new(1.0);
 
         // // Characteristic function
         let cf = dist.cf(1.0);
-        assert_approx_equal!(cf.re, 0.5, 1e-10);
-        assert_approx_equal!(cf.im, 0.5, 1e-10);
+        assert_approx_equal!(cf.re, 0.5, EPS);
+        assert_approx_equal!(cf.im, 0.5, EPS);
     }
 
     #[test]
@@ -241,11 +248,11 @@ mod tests {
         let dist: Exponential = Exponential::new(1.0);
 
         // Values computed using R
-        assert_approx_equal!(dist.pdf(0.0), 1.00000000, 1e-8);
-        assert_approx_equal!(dist.pdf(1.0), 0.36787944, 1e-8);
-        assert_approx_equal!(dist.pdf(2.0), 0.13533528, 1e-8);
-        assert_approx_equal!(dist.pdf(3.0), 0.04978707, 1e-8);
-        assert_approx_equal!(dist.pdf(4.0), 0.01831564, 1e-8);
+        assert_approx_equal!(dist.pdf(0.0), 1.000_000_00, EPS);
+        assert_approx_equal!(dist.pdf(1.0), 0.367_879_441_171_442_33, EPS);
+        assert_approx_equal!(dist.pdf(2.0), 0.135_335_283_236_612_7, EPS);
+        assert_approx_equal!(dist.pdf(3.0), 0.049_787_068_367_863_944, EPS);
+        assert_approx_equal!(dist.pdf(4.0), 0.018_315_638_888_734_18, EPS);
     }
 
     #[test]
@@ -253,10 +260,10 @@ mod tests {
         let dist: Exponential = Exponential::new(1.0);
 
         // Values computed using R
-        assert_approx_equal!(dist.cdf(0.0), 0.0000000, 1e-7);
-        assert_approx_equal!(dist.cdf(1.0), 0.6321206, 1e-7);
-        assert_approx_equal!(dist.cdf(2.0), 0.8646647, 1e-7);
-        assert_approx_equal!(dist.cdf(3.0), 0.9502129, 1e-7);
-        assert_approx_equal!(dist.cdf(4.0), 0.9816844, 1e-7);
+        assert_approx_equal!(dist.cdf(0.0), 0.000_000_0, EPS);
+        assert_approx_equal!(dist.cdf(1.0), 0.632_120_558_828_557_7, EPS);
+        assert_approx_equal!(dist.cdf(2.0), 0.864_664_716_763_387_3, EPS);
+        assert_approx_equal!(dist.cdf(3.0), 0.950_212_931_632_136, EPS);
+        assert_approx_equal!(dist.cdf(4.0), 0.981_684_361_111_265_8, EPS);
     }
 }

--- a/src/statistics/distributions/gamma.rs
+++ b/src/statistics/distributions/gamma.rs
@@ -38,6 +38,11 @@ pub struct Gamma {
 
 impl Gamma {
     /// New instance of a Gamma distribution.
+    ///
+    /// # Panics
+    ///
+    /// Panics if alpha and beta are not positive.
+    #[must_use]
     pub fn new(alpha: f64, beta: f64) -> Self {
         assert!(alpha > 0.0 && beta > 0.0);
 
@@ -148,6 +153,7 @@ impl Distribution for Gamma {
 mod tests {
     use super::*;
     use crate::assert_approx_equal;
+    use std::f64::EPSILON as EPS;
 
     #[test]
     fn test_gamma_characteristic_function() {
@@ -166,10 +172,10 @@ mod tests {
 
         // Values computed using R
         // assert_approx_equal!(dist.pdf(0.0), 1.00000000, 1e-8);
-        assert_approx_equal!(dist.pdf(1.0), 0.36787944, 1e-8);
-        assert_approx_equal!(dist.pdf(2.0), 0.13533528, 1e-8);
-        assert_approx_equal!(dist.pdf(3.0), 0.04978707, 1e-8);
-        assert_approx_equal!(dist.pdf(4.0), 0.01831564, 1e-8);
+        assert_approx_equal!(dist.pdf(1.0), 0.367_879_441_171_442_5, EPS);
+        assert_approx_equal!(dist.pdf(2.0), 0.135_335_283_236_612_76, EPS);
+        assert_approx_equal!(dist.pdf(3.0), 0.049_787_068_367_863_965, EPS);
+        assert_approx_equal!(dist.pdf(4.0), 0.018_315_638_888_734_186, EPS);
     }
 
     #[test]
@@ -178,9 +184,9 @@ mod tests {
 
         // Values computed using R
         // assert_approx_equal!(dist.cdf(0.0), 0.0000000, 1e-7);
-        assert_approx_equal!(dist.cdf(1.0), 0.6321206, 1e-7);
-        assert_approx_equal!(dist.cdf(2.0), 0.8646647, 1e-7);
-        assert_approx_equal!(dist.cdf(3.0), 0.9502129, 1e-7);
-        assert_approx_equal!(dist.cdf(4.0), 0.9816844, 1e-7);
+        assert_approx_equal!(dist.cdf(1.0), 0.632_120_558_828_558_1, EPS);
+        assert_approx_equal!(dist.cdf(2.0), 0.864_664_716_763_387_2, EPS);
+        assert_approx_equal!(dist.cdf(3.0), 0.950_212_931_632_136, EPS);
+        assert_approx_equal!(dist.cdf(4.0), 0.981_684_361_111_265_8, EPS);
     }
 }

--- a/src/statistics/distributions/gaussian.rs
+++ b/src/statistics/distributions/gaussian.rs
@@ -54,6 +54,11 @@ impl Gaussian {
     /// assert_approx_equal!(gaussian.cf(5.0).re, 3.7266532e-6, 1e-7);
     /// assert_eq!(gaussian.cf(5.0).im, 0.0);
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if variance is not positive.
+    #[must_use]
     pub fn new(mean: f64, variance: f64) -> Self {
         assert!(variance > 0.0);
 
@@ -306,6 +311,8 @@ mod tests_gaussian {
     use super::*;
     use crate::assert_approx_equal;
 
+    use std::f64::EPSILON as EPS;
+
     #[test]
     fn test_gaussian_characteristic_function() {
         // Standard normal distribution
@@ -314,8 +321,8 @@ mod tests_gaussian {
 
         // Characteristic function
         let cf = dist.cf(1.0);
-        assert_approx_equal!(cf.re, 1.0 / (1_f64.exp()).sqrt(), 1e-10);
-        assert_approx_equal!(cf.im, 0.0, 1e-10);
+        assert_approx_equal!(cf.re, 1.0 / (1_f64.exp()).sqrt(), EPS);
+        assert_approx_equal!(cf.im, 0.0, EPS);
     }
 
     #[test]
@@ -325,15 +332,15 @@ mod tests_gaussian {
         let dist: Gaussian = Gaussian::default();
 
         // Values from WolframAlpha
-        assert_approx_equal!(dist.pdf(-4.0), 0.00013383, 1e-8);
-        assert_approx_equal!(dist.pdf(-3.0), 0.00443185, 1e-8);
-        assert_approx_equal!(dist.pdf(-2.0), 0.05399097, 1e-8);
-        assert_approx_equal!(dist.pdf(-1.0), 0.24197072, 1e-8);
-        assert_approx_equal!(dist.pdf(0.0), 0.39894228, 1e-8);
-        assert_approx_equal!(dist.pdf(1.0), 0.24197072, 1e-8);
-        assert_approx_equal!(dist.pdf(2.0), 0.05399097, 1e-8);
-        assert_approx_equal!(dist.pdf(3.0), 0.00443185, 1e-8);
-        assert_approx_equal!(dist.pdf(4.0), 0.00013383, 1e-8);
+        assert_approx_equal!(dist.pdf(-4.0), 0.000_133_830_225_764_885_37, EPS);
+        assert_approx_equal!(dist.pdf(-3.0), 0.004_431_848_411_938_007_5, EPS);
+        assert_approx_equal!(dist.pdf(-2.0), 0.053_990_966_513_188_06, EPS);
+        assert_approx_equal!(dist.pdf(-1.0), 0.241_970_724_519_143_37, EPS);
+        assert_approx_equal!(dist.pdf(0.0), 0.398_942_280_401_432_7, EPS);
+        assert_approx_equal!(dist.pdf(1.0), 0.241_970_724_519_143_37, EPS);
+        assert_approx_equal!(dist.pdf(2.0), 0.053_990_966_513_188_06, EPS);
+        assert_approx_equal!(dist.pdf(3.0), 0.004_431_848_411_938_007_5, EPS);
+        assert_approx_equal!(dist.pdf(4.0), 0.000_133_830_225_764_885_37, EPS);
     }
 
     #[test]
@@ -343,15 +350,15 @@ mod tests_gaussian {
         let dist: Gaussian = Gaussian::default();
 
         // Values from WolframAlpha
-        assert_approx_equal!(dist.cdf(-4.0), 0.00003167, 1e-8);
-        assert_approx_equal!(dist.cdf(-3.0), 0.00134990, 1e-8);
-        assert_approx_equal!(dist.cdf(-2.0), 0.02275013, 1e-8);
-        assert_approx_equal!(dist.cdf(-1.0), 0.15865525, 1e-8);
-        assert_approx_equal!(dist.cdf(0.0), 0.5, 1e-8);
-        assert_approx_equal!(dist.cdf(1.0), 0.84134475, 1e-8);
-        assert_approx_equal!(dist.cdf(2.0), 0.97724987, 1e-8);
-        assert_approx_equal!(dist.cdf(3.0), 0.99865010, 1e-8);
-        assert_approx_equal!(dist.cdf(4.0), 0.99996833, 1e-8);
+        assert_approx_equal!(dist.cdf(-4.0), 0.000_031_671_241_835_663_76, EPS);
+        assert_approx_equal!(dist.cdf(-3.0), 0.001_349_898_031_574_464_2, EPS);
+        assert_approx_equal!(dist.cdf(-2.0), 0.022_750_131_947_162_62, EPS);
+        assert_approx_equal!(dist.cdf(-1.0), 0.158_655_253_945_057_25, EPS);
+        assert_approx_equal!(dist.cdf(0.0), 0.5, EPS);
+        assert_approx_equal!(dist.cdf(1.0), 0.841_344_746_054_942_8, EPS);
+        assert_approx_equal!(dist.cdf(2.0), 0.977_249_868_052_837_4, EPS);
+        assert_approx_equal!(dist.cdf(3.0), 0.998_650_101_968_425_5, EPS);
+        assert_approx_equal!(dist.cdf(4.0), 0.999_968_328_758_164_3, EPS);
     }
 
     #[test]
@@ -371,28 +378,28 @@ mod tests_gaussian {
     fn test_gaussian_moments() {
         let normal = Gaussian::default();
 
-        assert_approx_equal!(normal.mean(), 0.0, 1e-8);
-        assert_approx_equal!(normal.median(), 0.0, 1e-8);
-        assert_approx_equal!(normal.mode(), 0.0, 1e-8);
-        assert_approx_equal!(normal.variance(), 1.0, 1e-8);
-        assert_approx_equal!(normal.skewness(), 0.0, 1e-8);
-        assert_approx_equal!(normal.kurtosis(), 0.0, 1e-8);
-        assert_approx_equal!(normal.entropy(), 1.418_938_533_204_672_7, 1e-8);
+        assert_approx_equal!(normal.mean(), 0.0, EPS);
+        assert_approx_equal!(normal.median(), 0.0, EPS);
+        assert_approx_equal!(normal.mode(), 0.0, EPS);
+        assert_approx_equal!(normal.variance(), 1.0, EPS);
+        assert_approx_equal!(normal.skewness(), 0.0, EPS);
+        assert_approx_equal!(normal.kurtosis(), 0.0, EPS);
+        assert_approx_equal!(normal.entropy(), 1.418_938_533_204_672_7, EPS);
     }
 
     #[test]
     fn test_gaussian_mgf() {
         let normal = Gaussian::default();
 
-        assert_approx_equal!(normal.mgf(0.0), 1.0, 1e-8);
-        assert_approx_equal!(normal.mgf(1.0), 1.0_f64.exp().sqrt(), 1e-8);
-        assert_approx_equal!(normal.mgf(2.0), 1.0_f64.exp().powi(2), 1e-8);
+        assert_approx_equal!(normal.mgf(0.0), 1.0, EPS);
+        assert_approx_equal!(normal.mgf(1.0), 1.0_f64.exp().sqrt(), EPS);
+        assert_approx_equal!(normal.mgf(2.0), 7.389_056_098_930_65, EPS);
     }
 
     #[test]
     fn test_gaussian_entropy() {
         let normal = Gaussian::default();
 
-        assert_approx_equal!(normal.entropy(), 1.418_938_533_204_672_7, 1e-8);
+        assert_approx_equal!(normal.entropy(), 1.418_938_533_204_672_7, EPS);
     }
 }

--- a/src/statistics/distributions/uniform.rs
+++ b/src/statistics/distributions/uniform.rs
@@ -41,6 +41,11 @@ impl Uniform {
     ///
     /// assert_approx_equal!(dist.mean(), 0.5, 1e-7);
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if `a` is greater than `b`.
+    #[must_use]
     pub fn new(a: f64, b: f64, class: DistributionClass) -> Self {
         assert!(a <= b);
 
@@ -371,12 +376,12 @@ impl Distribution for Uniform {
         match self.class {
             DistributionClass::Discrete => {
                 for _ in 0..variates.capacity() {
-                    variates.push(dist.sample(&mut rng) as usize as f64)
+                    variates.push(dist.sample(&mut rng) as usize as f64);
                 }
             }
             DistributionClass::Continuous => {
                 for _ in 0..variates.capacity() {
-                    variates.push(dist.sample(&mut rng))
+                    variates.push(dist.sample(&mut rng));
                 }
             }
         }
@@ -393,6 +398,7 @@ impl Distribution for Uniform {
 mod tests {
     use super::*;
     use crate::assert_approx_equal;
+    use std::f64::EPSILON as EPS;
 
     #[test]
     fn test_uniform_distribution_continuous() {
@@ -400,16 +406,16 @@ mod tests {
 
         // Characteristic function
         let cf = dist.cf(1.0);
-        assert_approx_equal!(cf.re, 0.84147098480, 1e-10);
-        assert_approx_equal!(cf.im, 0.45969769413, 1e-10);
+        assert_approx_equal!(cf.re, 0.841_470_984_807_896_5, EPS);
+        assert_approx_equal!(cf.im, 0.459_697_694_131_860_23, EPS);
 
         // Probability mass function
         let pmf = dist.pmf(0.5);
-        assert_approx_equal!(pmf, 1.0, 1e-10);
+        assert_approx_equal!(pmf, 1.0, EPS);
 
         // Distribution function
         let cdf = dist.cdf(0.5);
-        assert_approx_equal!(cdf, 0.5, 1e-10);
+        assert_approx_equal!(cdf, 0.5, EPS);
     }
 
     #[test]
@@ -418,15 +424,15 @@ mod tests {
 
         // Characteristic function
         let cf = dist.cf(1.0);
-        assert_approx_equal!(cf.re, 0.77015115293, 1e-10);
-        assert_approx_equal!(cf.im, 0.42073549240, 1e-10);
+        assert_approx_equal!(cf.re, 0.770_151_152_934_069_9, EPS);
+        assert_approx_equal!(cf.im, 0.420_735_492_403_948_36, EPS);
 
         // Probability mass function
         let pmf = dist.pmf(0.5);
-        assert_approx_equal!(pmf, 0.5, 1e-10);
+        assert_approx_equal!(pmf, 0.5, EPS);
 
         // Distribution function
         let cdf = dist.cdf(0.5);
-        assert_approx_equal!(cdf, 0.5, 1e-10);
+        assert_approx_equal!(cdf, 0.5, EPS);
     }
 }

--- a/src/statistics/statistic.rs
+++ b/src/statistics/statistic.rs
@@ -163,9 +163,10 @@ impl Statistic<f64> for Vec<f64> {
         let std_dev_x = self.standard_deviation();
         let std_dev_y = other.standard_deviation();
 
-        if std_dev_x == 0.0 || std_dev_y == 0.0 {
-            panic!("Standard deviation should not be zero.");
-        }
+        assert!(
+            !(std_dev_x == 0.0 || std_dev_y == 0.0),
+            "Standard deviation should not be zero."
+        );
 
         cov / (std_dev_x * std_dev_y)
     }
@@ -287,26 +288,27 @@ mod tests_statistics {
 
     use super::*;
     use crate::assert_approx_equal;
+    use std::f64::EPSILON as EPS;
 
     #[test]
     fn test_mean_arithmetic() {
         let v = vec![1.0, 2.0, 3.0, 4.0, 5.0];
         let m = v.arithmetic_mean();
-        assert_eq!(m, 3.0);
+        assert_approx_equal!(m, 3.0, EPS);
     }
 
     #[test]
     fn test_mean_geometric() {
         let v = vec![1.0, 2.0, 4.0, 8.0, 16.0];
         let m = v.geometric_mean();
-        assert_approx_equal!(m, 4.0, 1e-10);
+        assert_approx_equal!(m, 4.0, EPS);
     }
 
     #[test]
     fn test_mean_harmonic() {
         let v = vec![1.0, 2.0, 4.0];
         let m = v.harmonic_mean();
-        assert_approx_equal!(m, 1.7142857, 1e-7);
+        assert_approx_equal!(m, 1.714_285_714_285_714_2, EPS);
     }
 
     #[test]
@@ -320,7 +322,7 @@ mod tests_statistics {
     fn test_standard_deviation() {
         let v = vec![1.0, 2.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0];
         let stddev = v.standard_deviation();
-        assert_approx_equal!(stddev, 2.559994, 1e-6);
+        assert_approx_equal!(stddev, 2.559_994_419_636_775, EPS);
     }
 
     #[test]
@@ -335,7 +337,7 @@ mod tests_statistics {
         let x = vec![2.1, 2.5, 4.0, 3.6];
         let y = vec![8.0, 10.0, 12.0, 14.0];
         let corr = x.correlation(&y);
-        assert_approx_equal!(corr, 0.8642268, 1e-6);
+        assert_approx_equal!(corr, 0.864_226_802_873_516_2, EPS);
     }
 
     #[test]
@@ -367,7 +369,7 @@ mod tests_statistics {
         let x = vec![2.1, 2.5, 4.0, 3.6];
         let y = vec![8.0, 10.0, 12.0, 14.0];
         let cov = x.covariance(&y);
-        assert_approx_equal!(cov, 2.0, 1e-10);
+        assert_approx_equal!(cov, 2.0, EPS);
     }
 
     #[test]
@@ -393,32 +395,32 @@ mod tests_statistics {
 
         // Population variance.
         let var_pop = v.population_variance();
-        assert_approx_equal!(var_pop, 2.0, 0.0001);
+        assert_approx_equal!(var_pop, 2.0, EPS);
 
         // Sample variance.
         let var_samp = v.variance();
-        assert_approx_equal!(var_samp, 2.5, 0.0001);
+        assert_approx_equal!(var_samp, 2.5, EPS);
     }
 
     #[test]
     fn test_population_standard_deviation() {
         let v = vec![1.0, 2.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0];
         let pop_stddev = v.population_standard_deviation();
-        assert_approx_equal!(pop_stddev, 2.3946555, 1e-6);
+        assert_approx_equal!(pop_stddev, 2.394_655_507_583_502, EPS);
     }
 
     #[test]
     fn test_sample_standard_deviation() {
         let v = vec![1.0, 2.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0];
         let samp_stddev = v.sample_standard_deviation();
-        assert_approx_equal!(samp_stddev, 2.559994, 1e-6);
+        assert_approx_equal!(samp_stddev, 2.559_994_419_636_775, EPS);
     }
 
     #[test]
     fn test_sample_standard_deviation_two_elements() {
         let v = vec![1.0, 2.0];
         let samp_stddev = v.sample_standard_deviation();
-        assert_approx_equal!(samp_stddev, std::f64::consts::FRAC_1_SQRT_2, 1e-7);
+        assert_approx_equal!(samp_stddev, std::f64::consts::FRAC_1_SQRT_2, EPS);
     }
 
     #[test]
@@ -432,7 +434,7 @@ mod tests_statistics {
     fn test_population_standard_deviation_two_elements() {
         let v = vec![1.0, 2.0];
         let pop_stddev = v.population_standard_deviation();
-        assert_approx_equal!(pop_stddev, 0.5, 1e-7);
+        assert_approx_equal!(pop_stddev, 0.5, EPS);
     }
 
     #[test]
@@ -452,13 +454,13 @@ mod tests_statistics {
     #[test]
     fn test_min_single_element() {
         let v = vec![42.0];
-        assert_eq!(v.min(), 42.0);
+        assert_approx_equal!(v.min(), 42.0, EPS);
     }
 
     #[test]
     fn test_max_single_element() {
         let v = vec![42.0];
-        assert_eq!(v.max(), 42.0);
+        assert_approx_equal!(v.max(), 42.0, EPS);
     }
 
     // #[test]

--- a/src/stochastics/arithmetic_brownian_motion.rs
+++ b/src/stochastics/arithmetic_brownian_motion.rs
@@ -7,7 +7,7 @@
 //      - LICENSE-MIT.md
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use crate::stochastics::*;
+use crate::stochastics::{StochasticProcess, TimeDependent};
 
 /// Struct containing the Arithmetic Brownian Motion parameters.
 pub struct ArithmeticBrownianMotion {
@@ -55,7 +55,7 @@ mod tests_abm {
     use crate::{assert_approx_equal, statistics::*};
 
     #[test]
-    fn test_arithmetic_brownian_motion() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_arithmetic_brownian_motion() {
         let abm = ArithmeticBrownianMotion::new(0.05, 0.9);
 
         let output = abm.euler_maruyama(10.0, 0.0, 0.5, 125, 1000, false);
@@ -69,7 +69,7 @@ mod tests_abm {
         let X_T: Vec<f64> = output
             .paths
             .iter()
-            .filter_map(|v| v.last().cloned())
+            .filter_map(|v| v.last().copied())
             .collect();
 
         let E_XT = X_T.mean();
@@ -78,7 +78,5 @@ mod tests_abm {
         assert_approx_equal!(E_XT, 10.0 + 0.05 * 0.5, 0.1);
         // V[X_T] = sigma^2 * T
         assert_approx_equal!(V_XT, 0.9 * 0.9 * 0.5, 0.1);
-
-        std::result::Result::Ok(())
     }
 }

--- a/src/stochastics/black_derman_toy.rs
+++ b/src/stochastics/black_derman_toy.rs
@@ -7,7 +7,7 @@
 //      - LICENSE-MIT.md
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use crate::stochastics::*;
+use crate::stochastics::{StochasticProcess, TimeDependent};
 
 /// Struct containing the Black-Derman-Toy process parameters.
 pub struct BlackDermanToy {
@@ -70,7 +70,7 @@ mod tests_black_derman_toy {
     // }
 
     #[test]
-    fn test_black_derman_toy_constant_sigma() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_black_derman_toy_constant_sigma() {
         let sigma = 0.13;
         let theta = 1.5;
 
@@ -82,18 +82,16 @@ mod tests_black_derman_toy {
         let X_T: Vec<f64> = output
             .paths
             .iter()
-            .filter_map(|v| v.last().cloned())
+            .filter_map(|v| v.last().copied())
             .collect();
 
         let E_XT = X_T.mean();
         assert!(E_XT.exp() >= 0.);
         // println!("Final expected short rate: {}", E_XT);
-
-        std::result::Result::Ok(())
     }
 
     #[test]
-    fn test_black_derman_toy_varying_sigma() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_black_derman_toy_varying_sigma() {
         let sigma = 0.13;
         let theta = 1.5;
 
@@ -105,13 +103,11 @@ mod tests_black_derman_toy {
         let X_T: Vec<f64> = output
             .paths
             .iter()
-            .filter_map(|v| v.last().cloned())
+            .filter_map(|v| v.last().copied())
             .collect();
 
         let E_XT = X_T.mean();
         assert!(E_XT.exp() >= 0.);
         // println!("Final expected short rate: {}", E_XT);
-
-        std::result::Result::Ok(())
     }
 }

--- a/src/stochastics/brownian_motion.rs
+++ b/src/stochastics/brownian_motion.rs
@@ -7,7 +7,7 @@
 //      - LICENSE-MIT.md
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use crate::stochastics::*;
+use crate::stochastics::StochasticProcess;
 
 /// Struct containing the Geometric Brownian Motion parameters.
 #[derive(Debug)]
@@ -21,6 +21,7 @@ impl Default for BrownianMotion {
 
 impl BrownianMotion {
     /// Create a new Geometric Brownian Motion process.
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
@@ -52,7 +53,7 @@ mod sde_tests {
     use crate::{assert_approx_equal, statistics::*};
 
     #[test]
-    fn test_brownian_motion() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_brownian_motion() {
         let bm = BrownianMotion::new();
 
         // AT LEAST 100 PATHS BEFORE PARALLEL IS WORTH IT.
@@ -91,7 +92,7 @@ mod sde_tests {
         let X_T: Vec<f64> = output_serial
             .paths
             .iter()
-            .filter_map(|v| v.last().cloned())
+            .filter_map(|v| v.last().copied())
             .collect();
 
         let E_XT = X_T.mean();
@@ -100,7 +101,5 @@ mod sde_tests {
         assert_approx_equal!(E_XT, 0.0, 0.5);
         // V[X_T] = T
         assert_approx_equal!(V_XT, 0.5, 0.5);
-
-        std::result::Result::Ok(())
     }
 }

--- a/src/stochastics/constant_elasticity_of_variance.rs
+++ b/src/stochastics/constant_elasticity_of_variance.rs
@@ -7,7 +7,7 @@
 //      - LICENSE-MIT.md
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use crate::stochastics::*;
+use crate::stochastics::{StochasticProcess, TimeDependent};
 
 /// Struct containing the CEV process parameters.
 pub struct ConstantElasticityOfVariance {
@@ -65,7 +65,7 @@ mod tests_cev {
     use crate::statistics::*;
 
     #[test]
-    fn test_cev_process() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_cev_process() {
         let cev = ConstantElasticityOfVariance::new(0.05, 0.9, 0.45);
 
         let output = cev.euler_maruyama(10.0, 0.0, 0.5, 100, 100, false);
@@ -74,7 +74,7 @@ mod tests_cev {
         let X_T: Vec<f64> = output
             .paths
             .iter()
-            .filter_map(|v| v.last().cloned())
+            .filter_map(|v| v.last().copied())
             .collect();
 
         let _E_XT = X_T.mean();
@@ -94,7 +94,5 @@ mod tests_cev {
         //         + (0.15 * 0.45 * 0.45 / (2. * 0.01)) * (1. - (-0.01 * 0.5_f64).exp()).powi(2),
         //     0.5
         // );
-
-        std::result::Result::Ok(())
     }
 }

--- a/src/stochastics/cox_ingersoll_ross.rs
+++ b/src/stochastics/cox_ingersoll_ross.rs
@@ -7,7 +7,7 @@
 //      - LICENSE-MIT.md
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use crate::stochastics::*;
+use crate::stochastics::{StochasticProcess, TimeDependent};
 
 /// Struct containing the Ornstein-Uhlenbeck process parameters.
 #[derive(Debug)]
@@ -63,7 +63,7 @@ mod tests_cir {
     use crate::{assert_approx_equal, statistics::*};
 
     #[test]
-    fn test_cox_ingersoll_ross() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_cox_ingersoll_ross() {
         let cir = CoxIngersollRoss::new(0.15, 0.45, 0.01);
 
         let output = cir.euler_maruyama(10.0, 0.0, 0.5, 100, 100, false);
@@ -72,7 +72,7 @@ mod tests_cir {
         let X_T: Vec<f64> = output
             .paths
             .iter()
-            .filter_map(|v| v.last().cloned())
+            .filter_map(|v| v.last().copied())
             .collect();
 
         let E_XT = X_T.mean();
@@ -95,7 +95,5 @@ mod tests_cir {
         // plot_vector((&output.trajectories[0]).clone(), file1).unwrap();
         // let file2 = "./images/CIR2.png";
         // plot_vector((&output.trajectories[1]).clone(), file2)
-
-        std::result::Result::Ok(())
     }
 }

--- a/src/stochastics/extended_vasicek.rs
+++ b/src/stochastics/extended_vasicek.rs
@@ -7,7 +7,7 @@
 //      - LICENSE-MIT.md
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use crate::stochastics::*;
+use crate::stochastics::{StochasticProcess, TimeDependent};
 
 /// Struct containing the extended Vasicek process parameters.
 pub struct ExtendedVasicek {
@@ -67,7 +67,7 @@ mod tests_extended_vasicek {
     // }
 
     #[test]
-    fn test_extended_vasicek() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_extended_vasicek() {
         let sigma = 2.0;
         let alpha = 2.0;
         let theta = 0.5;
@@ -80,7 +80,7 @@ mod tests_extended_vasicek {
         let X_T: Vec<f64> = output
             .paths
             .iter()
-            .filter_map(|v| v.last().cloned())
+            .filter_map(|v| v.last().copied())
             .collect();
 
         let E_XT = X_T.mean();
@@ -92,7 +92,5 @@ mod tests_extended_vasicek {
             (-alpha * 1.0_f64).exp() * 10.0 + (theta / alpha) * (1.0 - alpha * 1.0_f64).exp(),
             0.25
         );
-
-        std::result::Result::Ok(())
     }
 }

--- a/src/stochastics/fractional_ornstein_uhlenbeck.rs
+++ b/src/stochastics/fractional_ornstein_uhlenbeck.rs
@@ -7,7 +7,9 @@
 //      - LICENSE-MIT.md
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use crate::stochastics::*;
+use crate::stochastics::{
+    FractionalBrownianMotion, StochasticProcess, TimeDependent, Trajectories,
+};
 use rayon::prelude::*;
 
 /// Struct containing the Ornstein-Uhlenbeck process parameters.
@@ -105,12 +107,10 @@ mod tests_ornstein_uhlenbeck {
 
     #[test]
     #[ignore = "Hard to test."]
-    fn test_fractional_ornstein_uhlenbeck() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_fractional_ornstein_uhlenbeck() {
         let fou = FractionalOrnsteinUhlenbeck::new(0.15, 0.45, 0.01, 0.7);
 
         #[allow(dead_code)]
         let _output = fou.euler_maruyama(10.0, 0.0, 0.5, 100, 100, false);
-
-        std::result::Result::Ok(())
     }
 }

--- a/src/stochastics/geometric_brownian_bridge.rs
+++ b/src/stochastics/geometric_brownian_bridge.rs
@@ -1,4 +1,4 @@
-use crate::stochastics::*;
+use crate::stochastics::{StochasticProcess, TimeDependent};
 
 /// Struct containing the Geometric Brownian Bridge parameters.
 /// The Geometric Brownian Bridge is a stochastic process that models a path-dependent option.
@@ -62,7 +62,7 @@ mod tests_gbm_bridge {
 
     /// Test the Geometric Brownian Bridge process.
     #[test]
-    fn test_geometric_brownian_motion_bridge() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_geometric_brownian_motion_bridge() {
         let gbm = GeometricBrownianBridge::new(0.05, 0.9, 10.0, 0.5);
 
         let output = gbm.euler_maruyama(10.0, 0.0, 0.5, 125, 10000, false);
@@ -71,7 +71,7 @@ mod tests_gbm_bridge {
         let X_T: Vec<f64> = output
             .paths
             .iter()
-            .filter_map(|v| v.last().cloned())
+            .filter_map(|v| v.last().copied())
             .collect();
 
         let E_XT = X_T.mean();
@@ -80,7 +80,5 @@ mod tests_gbm_bridge {
         assert_approx_equal!(E_XT, 10.0, 0.5);
         // V[X_T] = https://en.wikipedia.org/wiki/Geometric_Brownian_motion
         assert_approx_equal!(V_XT, 0.0, 0.5);
-
-        std::result::Result::Ok(())
     }
 }

--- a/src/stochastics/geometric_brownian_motion.rs
+++ b/src/stochastics/geometric_brownian_motion.rs
@@ -7,7 +7,7 @@
 //      - LICENSE-MIT.md
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use crate::stochastics::*;
+use crate::stochastics::{StochasticProcess, TimeDependent};
 
 /// Struct containing the Geometric Brownian Motion parameters.
 pub struct GeometricBrownianMotion {
@@ -55,7 +55,7 @@ mod tests_gbm {
     use crate::{assert_approx_equal, statistics::*};
 
     #[test]
-    fn test_geometric_brownian_motion() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_geometric_brownian_motion() {
         let gbm = GeometricBrownianMotion::new(0.05, 0.9);
 
         let output = gbm.euler_maruyama(10.0, 0.0, 0.5, 125, 10000, false);
@@ -64,7 +64,7 @@ mod tests_gbm {
         let X_T: Vec<f64> = output
             .paths
             .iter()
-            .filter_map(|v| v.last().cloned())
+            .filter_map(|v| v.last().copied())
             .collect();
 
         let E_XT = X_T.mean();
@@ -82,7 +82,5 @@ mod tests_gbm {
         // plot_vector((&output.trajectories[0]).clone(), file1).unwrap();
         // let file2 = "./images/GBM2.png";
         // plot_vector((&output.trajectories[1]).clone(), file2)
-
-        std::result::Result::Ok(())
     }
 }

--- a/src/stochastics/ho_lee.rs
+++ b/src/stochastics/ho_lee.rs
@@ -7,7 +7,7 @@
 //      - LICENSE-MIT.md
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use crate::stochastics::*;
+use crate::stochastics::{StochasticProcess, TimeDependent};
 
 /// Struct containing the Ho-Lee process parameters.
 pub struct HoLee {
@@ -60,7 +60,7 @@ mod tests_ho_lee {
     // }
 
     #[test]
-    fn test_ho_lee() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_ho_lee() {
         let hl = HoLee::new(1.6, 2.0);
 
         // X_0 = 10.0
@@ -71,7 +71,7 @@ mod tests_ho_lee {
         let X_T: Vec<f64> = output
             .paths
             .iter()
-            .filter_map(|v| v.last().cloned())
+            .filter_map(|v| v.last().copied())
             .collect();
 
         let E_XT = X_T.mean();
@@ -83,7 +83,5 @@ mod tests_ho_lee {
         // Same here
         // V[X_T] = sigma^2 * T
         assert_approx_equal!(V_XT, 1.6 * 1.6 * 1.0, 0.5);
-
-        std::result::Result::Ok(())
     }
 }

--- a/src/stochastics/hull_white.rs
+++ b/src/stochastics/hull_white.rs
@@ -7,7 +7,7 @@
 //      - LICENSE-MIT.md
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use crate::stochastics::*;
+use crate::stochastics::{StochasticProcess, TimeDependent};
 
 /// Struct containing the Hull-White process parameters.
 pub struct HullWhite {
@@ -64,7 +64,7 @@ mod tests_hull_white {
     // }
 
     #[test]
-    fn test_hull_white() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_hull_white() {
         let alpha = 2.0;
         let theta = 0.5;
         let sigma = 2.0;
@@ -77,7 +77,7 @@ mod tests_hull_white {
         let X_T: Vec<f64> = output
             .paths
             .iter()
-            .filter_map(|v| v.last().cloned())
+            .filter_map(|v| v.last().copied())
             .collect();
 
         let E_XT = X_T.mean();
@@ -90,6 +90,5 @@ mod tests_hull_white {
 
         // No closed form solution for variance that I know of...
         // Have to take it on faith that it works
-        std::result::Result::Ok(())
     }
 }

--- a/src/stochastics/merton_jump_diffusion.rs
+++ b/src/stochastics/merton_jump_diffusion.rs
@@ -1,4 +1,4 @@
-use crate::stochastics::*;
+use crate::stochastics::{StochasticProcess, TimeDependent, Trajectories};
 
 use crate::statistics::{Distribution as LocalDistribution, Gaussian, Poisson};
 use rand::prelude::Distribution;
@@ -57,7 +57,7 @@ impl StochasticProcess for MertonJumpDiffusion {
     }
 
     fn jump(&self, _x: f64, _t: f64) -> Option<f64> {
-        self.gaussian.sample(1).unwrap().first().cloned()
+        self.gaussian.sample(1).unwrap().first().copied()
     }
 
     fn euler_maruyama(
@@ -100,7 +100,7 @@ impl StochasticProcess for MertonJumpDiffusion {
                 } else {
                     path[t + 1] = path[t]
                         + self.drift(path[t], times[t]) * dt
-                        + self.diffusion(path[t], times[t]) * dW[t]
+                        + self.diffusion(path[t], times[t]) * dW[t];
                 }
             }
         };
@@ -121,7 +121,7 @@ mod tests_gbm_bridge {
     use crate::{assert_approx_equal, statistics::*};
 
     #[test]
-    fn test_geometric_brownian_motion_bridge() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_geometric_brownian_motion_bridge() {
         let mjd = MertonJumpDiffusion::new(0.05, 0.9, 1.0, 0.0, 0.3);
 
         let output = mjd.euler_maruyama(10.0, 0.0, 0.5, 125, 10000, false);
@@ -130,7 +130,7 @@ mod tests_gbm_bridge {
         let X_T: Vec<f64> = output
             .paths
             .iter()
-            .filter_map(|v| v.last().cloned())
+            .filter_map(|v| v.last().copied())
             .collect();
 
         println!("X_T = {:?}", X_T);
@@ -145,7 +145,5 @@ mod tests_gbm_bridge {
             10. * 10. * (2. * 0.05 * 0.5_f64).exp() * ((0.9 * 0.9 * 0.5_f64).exp() - 1.),
             5.0
         );
-
-        std::result::Result::Ok(())
     }
 }

--- a/src/stochastics/ornstein_uhlenbeck.rs
+++ b/src/stochastics/ornstein_uhlenbeck.rs
@@ -7,7 +7,7 @@
 //      - LICENSE-MIT.md
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use crate::stochastics::*;
+use crate::stochastics::{StochasticProcess, TimeDependent};
 
 /// Struct containing the Ornstein-Uhlenbeck process parameters.
 pub struct OrnsteinUhlenbeck {
@@ -62,7 +62,7 @@ mod tests_ornstein_uhlenbeck {
     use crate::{assert_approx_equal, statistics::*};
 
     #[test]
-    fn test_ornstein_uhlenbeck() -> Result<(), Box<dyn std::error::Error>> {
+    fn test_ornstein_uhlenbeck() {
         let ou = OrnsteinUhlenbeck::new(0.15, 0.45, 0.01);
 
         let output = ou.euler_maruyama(10.0, 0.0, 0.5, 100, 100, false);
@@ -71,7 +71,7 @@ mod tests_ornstein_uhlenbeck {
         let X_T: Vec<f64> = output
             .paths
             .iter()
-            .filter_map(|v| v.last().cloned())
+            .filter_map(|v| v.last().copied())
             .collect();
 
         let E_XT = X_T.mean();
@@ -93,7 +93,5 @@ mod tests_ornstein_uhlenbeck {
         // plot_vector((&output.trajectories[0]).clone(), file1).unwrap();
         // let file2 = "./images/OU2.png";
         // plot_vector((&output.trajectories[1]).clone(), file2)
-
-        std::result::Result::Ok(())
     }
 }

--- a/src/stochastics/process.rs
+++ b/src/stochastics/process.rs
@@ -55,6 +55,7 @@ pub struct Trajectories {
 }
 
 /// Trait to implement stochastic processes.
+#[allow(clippy::module_name_repetitions)]
 pub trait StochasticProcess: Sync {
     /// Base method for the process' drift.
     fn drift(&self, x: f64, t: f64) -> f64;

--- a/src/time/calendar.rs
+++ b/src/time/calendar.rs
@@ -24,7 +24,7 @@ pub trait Calendar {
     /// Returns the ISO 10383 market identifier code.
     fn market_identifier_code(&self) -> crate::iso::ISO_10383;
 
-    /// Unpacks an OffsetDateTime into a tuple in the following form:
+    /// Unpacks an `OffsetDateTime` into a tuple in the following form:
     ///
     /// ```ignore
     /// (
@@ -47,13 +47,15 @@ pub trait Calendar {
     }
 
     /// Returns the Easter Monday for the given year.
+    #[must_use]
     fn easter_monday(year: usize, is_orthodox: bool) -> u16 {
-        let index = if is_orthodox { 1 } else { 0 };
+        let index = usize::from(is_orthodox);
 
         super::EASTER_MONDAYS[index][year - 1901]
     }
 
     /// Checks if date is a weekend.
+    #[must_use]
     fn is_weekend(date: OffsetDateTime) -> bool {
         let w = date.weekday();
 

--- a/src/time/calendars/china.rs
+++ b/src/time/calendars/china.rs
@@ -26,7 +26,7 @@ impl Calendar for China {
         crate::iso::XSHG
     }
 
-    #[allow(clippy::manual_range_contains)]
+    #[allow(clippy::manual_range_contains, clippy::too_many_lines)]
     fn is_business_day(&self, date: OffsetDateTime) -> bool {
         let (_, d, m, y, _) = self.unpack_date(date);
 

--- a/src/time/calendars/finland.rs
+++ b/src/time/calendars/finland.rs
@@ -44,7 +44,7 @@ impl Calendar for Finland {
             // Labour Day
             || (d == 1 && m == Month::May)
             // Midsummer Eve (Friday between June 18-24)
-            || (w == Weekday::Friday && (d >= 18 && d <= 24) && m == Month::June)
+            || (w == Weekday::Friday && (18..=24).contains(&d) && m == Month::June)
             // Independence Day
             || (d == 6 && m == Month::December)
             // Christmas Eve

--- a/src/time/calendars/hong_kong.rs
+++ b/src/time/calendars/hong_kong.rs
@@ -372,179 +372,180 @@ impl Calendar for HongKong {
     }
 }
 
+#[allow(clippy::unnested_or_patterns)]
 fn is_lunar_new_year(year: i32, day: u8, month: Month) -> bool {
-    if year == 2004 && month == Month::January && (day == 22 || day == 23 || day == 24)
-        || year == 2005 && month == Month::February && (day == 9 || day == 10 || day == 11)
-        || year == 2006 && month == Month::January && (day == 28 || day == 29 || day == 30)
-        || year == 2007 && month == Month::February && (day == 17 || day == 18 || day == 19)
-        || year == 2008 && month == Month::February && (day == 7 || day == 8 || day == 9)
-        || year == 2009 && month == Month::January && (day == 26 || day == 27 || day == 28)
-        || year == 2010 && month == Month::February && (day == 13 || day == 14 || day == 15)
-        || year == 2011 && month == Month::February && (day == 2 || day == 3 || day == 4)
-        || year == 2012 && month == Month::January && (day == 23 || day == 24 || day == 25)
-        || year == 2013 && month == Month::February && (day == 10 || day == 11 || day == 12)
-        || year == 2014 && month == Month::January && (day == 31 || day == 1 || day == 2)
-        || year == 2015 && month == Month::February && (day == 19 || day == 20 || day == 21)
-        || year == 2016 && month == Month::February && (day == 8 || day == 9 || day == 10)
-        || year == 2017 && month == Month::January && (day == 28 || day == 29 || day == 30)
-        || year == 2018 && month == Month::February && (day == 16 || day == 17 || day == 18)
-        || year == 2019 && month == Month::February && (day == 5 || day == 6 || day == 7)
-        || year == 2020 && month == Month::January && (day == 25 || day == 27 || day == 28)
-    {
-        return true;
-    }
-
-    false
+    use Month::{February, January};
+    matches!(
+        (year, day, month),
+        (2004, 22..=24, January)
+            | (2005, 9..=11, February)
+            | (2006, 28..=30, January)
+            | (2007, 17..=19, February)
+            | (2008, 7..=9, February)
+            | (2009, 26..=28, January)
+            | (2010, 13..=15, February)
+            | (2011, 2..=4, February)
+            | (2012, 23..=25, January)
+            | (2013, 10..=12, February)
+            | (2014, 31 | 1 | 2, January)
+            | (2015, 19..=21, February)
+            | (2016, 8..=10, February)
+            | (2017, 28..=30, January)
+            | (2018, 16..=18, February)
+            | (2019, 5..=7, February)
+            | (2020, 25 | 27 | 28, January)
+    )
 }
 
+#[allow(clippy::unnested_or_patterns)]
 fn is_buddhas_birthday(year: i32, day: u8, month: Month) -> bool {
-    if year == 2004 && month == Month::May && day == 26
-        || year == 2005 && month == Month::May && day == 16
-        || year == 2006 && month == Month::May && day == 5
-        || year == 2007 && month == Month::May && day == 24
-        || year == 2008 && month == Month::May && day == 12
-        || year == 2009 && month == Month::May && day == 2
-        || year == 2010 && month == Month::May && day == 21
-        || year == 2011 && month == Month::May && day == 10
-        || year == 2012 && month == Month::May && day == 28
-        || year == 2013 && month == Month::May && day == 17
-        || year == 2014 && month == Month::May && day == 6
-        || year == 2015 && month == Month::May && day == 25
-        || year == 2016 && month == Month::May && day == 14
-        || year == 2017 && month == Month::May && day == 3
-        || year == 2018 && month == Month::May && day == 22
-        || year == 2019 && month == Month::May && day == 12
-        || year == 2020 && month == Month::May && day == 30
-    {
-        return true;
-    }
-
-    false
+    use Month::May;
+    matches!(
+        (year, day, month),
+        (2004, 26, May)
+            | (2005, 16, May)
+            | (2006, 5, May)
+            | (2007, 24, May)
+            | (2008, 12, May)
+            | (2009, 2, May)
+            | (2010, 21, May)
+            | (2011, 10, May)
+            | (2012, 28, May)
+            | (2013, 17, May)
+            | (2014, 6, May)
+            | (2015, 25, May)
+            | (2016, 14, May)
+            | (2017, 3, May)
+            | (2018, 22, May)
+            | (2019, 12, May)
+            | (2020, 30, May)
+    )
 }
 
+#[allow(clippy::unnested_or_patterns)]
 fn is_ching_ming_festival(year: i32, day: u8, month: Month) -> bool {
-    if year == 2004 && month == Month::April && day == 5
-        || year == 2005 && month == Month::April && day == 5
-        || year == 2006 && month == Month::April && day == 5
-        || year == 2007 && month == Month::April && day == 5
-        || year == 2008 && month == Month::April && day == 4
-        || year == 2009 && month == Month::April && day == 4
-        || year == 2010 && month == Month::April && day == 5
-        || year == 2011 && month == Month::April && day == 5
-        || year == 2012 && month == Month::April && day == 4
-        || year == 2013 && month == Month::April && day == 4
-        || year == 2014 && month == Month::April && day == 5
-        || year == 2015 && month == Month::April && day == 5
-        || year == 2016 && month == Month::April && day == 4
-        || year == 2017 && month == Month::April && day == 4
-        || year == 2018 && month == Month::April && day == 5
-        || year == 2019 && month == Month::April && day == 5
-        || year == 2020 && month == Month::April && day == 4
-    {
-        return true;
-    }
-
-    false
+    use Month::April;
+    matches!(
+        (year, day, month),
+        (2004, 5, April)
+            | (2005, 5, April)
+            | (2006, 5, April)
+            | (2007, 5, April)
+            | (2008, 4, April)
+            | (2009, 4, April)
+            | (2010, 5, April)
+            | (2011, 5, April)
+            | (2012, 4, April)
+            | (2013, 4, April)
+            | (2014, 5, April)
+            | (2015, 5, April)
+            | (2016, 4, April)
+            | (2017, 4, April)
+            | (2018, 5, April)
+            | (2019, 5, April)
+            | (2020, 4, April)
+    )
 }
 
+#[allow(clippy::unnested_or_patterns)]
 fn is_tuen_ng_festival(year: i32, day: u8, month: Month) -> bool {
-    if year == 2004 && month == Month::June && day == 22
-        || year == 2005 && month == Month::June && day == 11
-        || year == 2006 && month == Month::June && day == 1
-        || year == 2007 && month == Month::June && day == 19
-        || year == 2008 && month == Month::June && day == 9
-        || year == 2009 && month == Month::June && day == 28
-        || year == 2010 && month == Month::June && day == 16
-        || year == 2011 && month == Month::June && day == 6
-        || year == 2012 && month == Month::June && day == 23
-        || year == 2013 && month == Month::June && day == 12
-        || year == 2014 && month == Month::June && day == 2
-        || year == 2015 && month == Month::June && day == 20
-        || year == 2016 && month == Month::June && day == 9
-        || year == 2017 && month == Month::May && day == 30
-        || year == 2018 && month == Month::June && day == 18
-        || year == 2019 && month == Month::June && day == 7
-        || year == 2020 && month == Month::June && day == 25
-    {
-        return true;
-    }
+    use Month::{June, May};
 
-    false
+    matches!(
+        (year, day, month),
+        (2004, 22, June)
+            | (2005, 11, June)
+            | (2006, 1, June)
+            | (2007, 19, June)
+            | (2008, 9, June)
+            | (2009, 28, June)
+            | (2010, 16, June)
+            | (2011, 6, June)
+            | (2012, 23, June)
+            | (2013, 12, June)
+            | (2014, 2, June)
+            | (2015, 20, June)
+            | (2016, 9, June)
+            | (2017, 30, May)
+            | (2018, 18, June)
+            | (2019, 7, June)
+            | (2020, 25, June)
+    )
 }
 
+#[allow(clippy::unnested_or_patterns)]
 fn is_mid_autumn_festival(year: i32, day: u8, month: Month) -> bool {
-    if year == 2004 && month == Month::September && day == 28
-        || year == 2005 && month == Month::September && day == 18
-        || year == 2006 && month == Month::October && day == 7
-        || year == 2007 && month == Month::September && day == 26
-        || year == 2008 && month == Month::September && day == 15
-        || year == 2009 && month == Month::October && day == 3
-        || year == 2010 && month == Month::September && day == 22
-        || year == 2011 && month == Month::September && day == 12
-        || year == 2012 && month == Month::September && day == 30
-        || year == 2013 && month == Month::September && day == 19
-        || year == 2014 && month == Month::September && day == 9
-        || year == 2015 && month == Month::September && day == 27
-        || year == 2016 && month == Month::September && day == 15
-        || year == 2017 && month == Month::October && day == 5
-        || year == 2018 && month == Month::September && day == 25
-        || year == 2019 && month == Month::September && day == 14
-        || year == 2020 && month == Month::October && day == 1
-    {
-        return true;
-    }
-
-    false
+    use Month::{October, September};
+    matches!(
+        (year, day, month),
+        (2004, 28, September)
+            | (2005, 18, September)
+            | (2006, 7, October)
+            | (2007, 26, September)
+            | (2008, 15, September)
+            | (2009, 3, October)
+            | (2010, 22, September)
+            | (2011, 12, September)
+            | (2012, 30, September)
+            | (2013, 19, September)
+            | (2014, 9, September)
+            | (2015, 27, September)
+            | (2016, 15, September)
+            | (2017, 5, October)
+            | (2018, 25, September)
+            | (2019, 14, September)
+            | (2020, 1, October)
+    )
 }
 
+#[allow(clippy::unnested_or_patterns)]
 fn is_chung_yeung_festival(year: i32, day: u8, month: Month) -> bool {
-    if year == 2004 && month == Month::October && day == 28
-        || year == 2005 && month == Month::October && day == 18
-        || year == 2006 && month == Month::October && day == 7
-        || year == 2007 && month == Month::October && day == 26
-        || year == 2008 && month == Month::October && day == 16
-        || year == 2009 && month == Month::October && day == 26
-        || year == 2010 && month == Month::October && day == 16
-        || year == 2011 && month == Month::October && day == 5
-        || year == 2012 && month == Month::October && day == 23
-        || year == 2013 && month == Month::October && day == 14
-        || year == 2014 && month == Month::October && day == 2
-        || year == 2015 && month == Month::October && day == 21
-        || year == 2016 && month == Month::October && day == 10
-        || year == 2017 && month == Month::October && day == 28
-        || year == 2018 && month == Month::October && day == 17
-        || year == 2019 && month == Month::October && day == 7
-        || year == 2020 && month == Month::October && day == 26
-    {
-        return true;
-    }
-
-    false
+    use Month::October;
+    matches!(
+        (year, day, month),
+        (2004, 28, October)
+            | (2005, 18, October)
+            | (2006, 7, October)
+            | (2007, 26, October)
+            | (2008, 16, October)
+            | (2009, 26, October)
+            | (2010, 16, October)
+            | (2011, 5, October)
+            | (2012, 23, October)
+            | (2013, 14, October)
+            | (2014, 2, October)
+            | (2015, 21, October)
+            | (2016, 10, October)
+            | (2017, 28, October)
+            | (2018, 17, October)
+            | (2019, 7, October)
+            | (2020, 26, October)
+    )
 }
 
+#[allow(clippy::unnested_or_patterns)]
 fn is_second_day_after_christmas(year: i32, day: u8, month: Month) -> bool {
-    if year == 2004 && month == Month::December && day == 27
-        || year == 2005 && month == Month::December && day == 27
-        || year == 2006 && month == Month::December && day == 27
-        || year == 2007 && month == Month::December && day == 27
-        || year == 2008 && month == Month::December && day == 29
-        || year == 2009 && month == Month::December && day == 28
-        || year == 2010 && month == Month::December && day == 27
-        || year == 2011 && month == Month::December && day == 27
-        || year == 2012 && month == Month::December && day == 27
-        || year == 2013 && month == Month::December && day == 27
-        || year == 2014 && month == Month::December && day == 29
-        || year == 2015 && month == Month::December && day == 28
-        || year == 2016 && month == Month::December && day == 27
-        || year == 2017 && month == Month::December && day == 27
-        || year == 2018 && month == Month::December && day == 27
-        || year == 2019 && month == Month::December && day == 27
-        || year == 2020 && month == Month::December && day == 28
-    {
-        return true;
-    }
-
-    false
+    use Month::December;
+    matches!(
+        (year, day, month),
+        (2004, 27, December)
+            | (2005, 27, December)
+            | (2006, 27, December)
+            | (2007, 27, December)
+            | (2008, 29, December)
+            | (2009, 28, December)
+            | (2010, 27, December)
+            | (2011, 27, December)
+            | (2012, 27, December)
+            | (2013, 27, December)
+            | (2014, 29, December)
+            | (2015, 28, December)
+            | (2016, 27, December)
+            | (2017, 27, December)
+            | (2018, 27, December)
+            | (2019, 27, December)
+            | (2020, 28, December)
+    )
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/time/schedule.rs
+++ b/src/time/schedule.rs
@@ -55,6 +55,7 @@ pub struct Schedule {
 impl Schedule {
     /// Creates a new schedule from a given start date, period length, and number
     /// of periods in the schedule.
+    #[must_use]
     pub fn new_from_start(start: OffsetDateTime, period: Duration, num_periods: i64) -> Schedule {
         let mut payments = Vec::with_capacity(num_periods as usize + 1);
         let mut current_time = start;
@@ -76,6 +77,7 @@ impl Schedule {
 
     /// Creates a new schedule from a given end date, period length, and number
     /// of periods in the schedule.
+    #[must_use]
     pub fn new_from_end(end: OffsetDateTime, period: Duration, num_periods: i64) -> Schedule {
         let mut payments = Vec::with_capacity(num_periods as usize + 1);
 
@@ -100,7 +102,8 @@ impl Schedule {
 
     /// Creates a new schedule from a vector of dates.
     /// Dates must be in ascending order.
-    pub fn new_from_dates(dates: Vec<OffsetDateTime>) -> Schedule {
+    #[must_use]
+    pub fn new_from_dates(dates: &Vec<OffsetDateTime>) -> Schedule {
         assert!(&dates.windows(2).all(|window| window[0] < window[1]));
 
         Schedule {
@@ -183,7 +186,7 @@ mod test_schedule {
             datetime!(2023-07-01 0:0:0 UTC),
             datetime!(2023-08-01 0:0:0 UTC),
         ];
-        let schedule = Schedule::new_from_dates(dates.clone());
+        let schedule = Schedule::new_from_dates(&dates);
         assert_eq!(schedule.dates, dates);
     }
 
@@ -194,7 +197,7 @@ mod test_schedule {
             datetime!(2023-07-01 0:0:0 UTC),
             datetime!(2023-06-01 0:0:0 UTC),
         ];
-        Schedule::new_from_dates(dates);
+        let _ = Schedule::new_from_dates(&dates);
     }
 
     #[test]

--- a/src/trading/limit_order_book/limit.rs
+++ b/src/trading/limit_order_book/limit.rs
@@ -34,11 +34,11 @@ impl Limit {
         self.orders.push_back(order_id);
     }
 
-    pub fn cancel(&mut self, order_id: &u64) -> bool {
+    pub fn cancel(&mut self, order_id: u64) -> bool {
         let index = self
             .orders
             .iter()
-            .position(|id| id == order_id)
+            .position(|id| id == &order_id)
             .expect("This limit should have this id but doesn't");
 
         self.orders.remove(index);
@@ -46,10 +46,10 @@ impl Limit {
         self.orders.is_empty()
     }
 
-    pub fn execute(&mut self, shares: &u64, order_map: &mut HashMap<u64, Order>) -> (u64, bool) {
+    pub fn execute(&mut self, shares: u64, order_map: &mut HashMap<u64, Order>) -> (u64, bool) {
         let mut executed_shares = 0;
 
-        while &executed_shares < shares && !self.orders.is_empty() {
+        while executed_shares < shares && !self.orders.is_empty() {
             let order_id = self.orders.front().unwrap();
             let order_shares = order_map.get(order_id).unwrap().shares;
 

--- a/src/trading/order.rs
+++ b/src/trading/order.rs
@@ -13,6 +13,7 @@ use super::{order_lifespan::OrderTimeInForce, order_side::OrderSide, order_type:
 use time::OffsetDateTime;
 
 /// Order ID type.
+#[allow(clippy::module_name_repetitions)]
 pub type OrderID = u64;
 
 /// Order struct containing parameters for a given order in the LOB.
@@ -118,51 +119,61 @@ impl Order {
     }
 
     /// Get the `Order` ID.
+    #[must_use]
     pub fn id(&self) -> u64 {
         self.id
     }
 
     /// Get the `Order` symbol ID.
+    #[must_use]
     pub fn symbol_id(&self) -> u32 {
         self.symbol_id
     }
 
     /// Get the `Order` type.
+    #[must_use]
     pub fn order_type(&self) -> &OrderType {
         &self.order_type
     }
 
     /// Get the `Order` side.
+    #[must_use]
     pub fn order_side(&self) -> &OrderSide {
         &self.order_side
     }
 
     /// Get the `Order` price.
+    #[must_use]
     pub fn price(&self) -> f64 {
         self.price
     }
 
     /// Get the `Order` stop price.
+    #[must_use]
     pub fn stop_price(&self) -> f64 {
         self.stop_price
     }
 
     /// Get the `Order` quantity.
+    #[must_use]
     pub fn quantity(&self) -> u64 {
         self.quantity
     }
 
     /// Get the `Order` executed quantity.
+    #[must_use]
     pub fn executed_quantity(&self) -> u64 {
         self.executed_quantity
     }
 
     /// Get the `Order` leaves quantity.
+    #[must_use]
     pub fn leaves_quantity(&self) -> u64 {
         self.leaves_quantity
     }
 
     /// Get the `Order` time in force.
+    #[must_use]
     pub fn time_in_force(&self) -> &OrderTimeInForce {
         &self.time_in_force
     }
@@ -173,6 +184,7 @@ impl Order {
     // }
 
     /// Get the `Order` timestamp.
+    #[must_use]
     pub fn timestamp(&self) -> OffsetDateTime {
         self.timestamp
     }

--- a/src/trading/order_book.rs
+++ b/src/trading/order_book.rs
@@ -16,7 +16,7 @@ use std::collections::VecDeque;
 /// The half-books are double-ended queues,
 /// one for the bids (buy orders) and one for the asks (sell orders).
 ///
-/// VecDeque\<T\> is not the most efficient choice, but it is convenient
+/// `VecDeque`\<T\> is not the most efficient choice, but it is convenient
 /// since we can push/pop from both the front and back easily.
 #[derive(Debug, Clone)]
 pub struct OrderBook {
@@ -35,7 +35,8 @@ impl Default for OrderBook {
 
 impl OrderBook {
     /// New `OrderBook` instance.
-    pub fn new() -> Self {
+    #[must_use]
+    pub const fn new() -> Self {
         Self {
             bids: VecDeque::new(),
             asks: VecDeque::new(),
@@ -51,11 +52,13 @@ impl OrderBook {
     }
 
     /// Check if `OrderBook` is empty.
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.bids.is_empty() && self.asks.is_empty()
     }
 
     /// Get the size of the `OrderBook`.
+    #[must_use]
     pub fn len(&self) -> usize {
         self.bids.len() + self.asks.len()
     }


### PR DESCRIPTION
I turned on `clippy::pedantic`, which yielded many errors. I attempted to fix most of the errors, but some are remaining.

One of the prominent categories of errors (which I will fix next) is casting errors. For example, many times, the library casts from `f64` to `usize` or from `i32` to `usize`. Some of these `f64` -> `usize` are a result of the library using a float to represent a 1.0 or a 0.0 (see bernoulli.rs). Additionally, I think another thing to think about is the use of `usize` in contexts other than indexing, which happens quite often.