### PR TITLE
Add calendar for Hungary

### DIFF
--- a/src/time/calendars/botswana.rs
+++ b/src/time/calendars/botswana.rs
@@ -32,7 +32,7 @@ impl Calendar for Botswana {
 
         if Self::is_weekend(date)
         // New Year's Day (possibly moved to Monday or Tuesday)
-        || ((d == 1 || (d == 2 && w == Weekday::Monday) || (d == 3 && w == Weekday::Tuesday)) 
+        || ((d == 1 || (d == 2 && w == Weekday::Monday) || (d == 3 && w == Weekday::Tuesday))
             && m == Month::January)
         // Good Friday
         || (dd == em - 3)
@@ -49,10 +49,10 @@ impl Calendar for Botswana {
         // Presidents' Day (third Monday of July)
         || ((15..=21).contains(&d) && w == Weekday::Monday && m == Month::July)
         // Independence Day, September 30th (possibly moved to Monday)
-        || ((d == 30 && m == Month::September) || 
+        || ((d == 30 && m == Month::September) ||
             (d == 1  && w == Weekday::Monday && m == Month::October))
         // Botswana Day, October 1st (possibly moved to Monday or Tuesday)
-        || ((d == 1 || (d == 2 && w == Weekday::Monday) || (d == 3 && w == Weekday::Tuesday)) 
+        || ((d == 1 || (d == 2 && w == Weekday::Monday) || (d == 3 && w == Weekday::Tuesday))
             && m == Month::October)
         // Christmas
         || (d == 25 && m == Month::December)

--- a/src/time/calendars/china.rs
+++ b/src/time/calendars/china.rs
@@ -144,7 +144,7 @@ impl Calendar for China {
             || (y == 2022 && d == 12 && m == Month::September)
             || (y == 2023 && d == 29 && m == Month::September)
             // National Day
-            || (y <= 2007 && d >= 1 && d <= 7 && m == Month::October) 
+            || (y <= 2007 && d >= 1 && d <= 7 && m == Month::October)
             || (y == 2008 && ((d >= 29 && m == Month::September) ||
                             (d <= 3 && m == Month::October)))
             || (y == 2009 && d >= 1 && d <= 8 && m == Month::October)

--- a/src/time/calendars/hungary.rs
+++ b/src/time/calendars/hungary.rs
@@ -8,21 +8,52 @@
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 use crate::time::Calendar;
-use time::{Month, OffsetDateTime, Weekday};
+use time::{Month, OffsetDateTime};
 
-/// Czech Republic calendar.
-pub struct CzechRepublic;
+/// Hungary calendar.
+pub struct Hungary;
 
-impl Calendar for CzechRepublic {
+impl Calendar for Hungary {
     fn name(&self) -> &'static str {
-        ""
+        "Hungary"
+    }
+
+    fn country_code(&self) -> crate::iso::ISO_3166 {
+        crate::iso::HUNGARY
+    }
+
+    fn market_identifier_code(&self) -> crate::iso::ISO_10383 {
+        crate::iso::XBUD
     }
 
     fn is_business_day(&self, date: OffsetDateTime) -> bool {
-        let (w, d, m, y, dd) = self.unpack_date(date);
+        let (_, d, m, y, dd) = self.unpack_date(date);
         let em = Self::easter_monday(y as usize, false);
 
-        if Self::is_weekend(date) {
+        if Self::is_weekend(date)
+            // New Year's Day
+            || (d == 1 && m == Month::January)
+            // 1848 Revolution Memorial Day
+            || (d == 15 && m == Month::March)
+            // Good Friday
+            || (dd == em - 3)
+            // Easter Monday
+            || (dd == em)
+            // Labor Day / May Day
+            || (d == 1 && m == Month::May)
+            // Whit Monday
+            || (dd == em + 49)
+            // Hungary National Day
+            || (d == 20 && m == Month::August)
+            // 1956 Revolution Memorial Day
+            || (d == 23 && m == Month::October)
+            // All Saints' Day
+            || (d == 1 && m == Month::November)
+            // Christmas
+            || (d == 25 && m == Month::December)
+            // Second Day of Christmas
+            || (d == 26 && m == Month::December)
+        {
             return false;
         }
 
@@ -35,4 +66,58 @@ impl Calendar for CzechRepublic {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 #[cfg(test)]
-mod tests {}
+mod test_hungary {
+    use super::*;
+    use time::macros::datetime;
+
+    // Test to verify the name() method.
+    #[test]
+    fn test_name() {
+        let calendar = Hungary;
+        assert_eq!(calendar.name(), "Hungary");
+    }
+
+    // Test to verify if weekends are not considered business days.
+    #[test]
+    fn test_is_weekend() {
+        let calendar = Hungary;
+        let sat = datetime!(2024-01-13 12:00:00 UTC);
+        let sun = datetime!(2024-01-14 12:00:00 UTC);
+        assert!(!calendar.is_business_day(sat));
+        assert!(!calendar.is_business_day(sun));
+    }
+
+    // Test to verify if the is_business_day() method properly accounts for public holidays.
+    #[test]
+    fn test_is_public_holiday() {
+        let calendar = Hungary;
+        let new_years_day = datetime!(2024-01-01 12:00:00 UTC);
+        let revolution_1848_day = datetime!(2024-03-15 12:00:00 UTC);
+        let labour_day = datetime!(2024-05-01 12:00:00 UTC);
+        let national_holiday = datetime!(2024-08-20 12:00:00 UTC);
+        let revolution_1956_day = datetime!(2024-10-23 12:00:00 UTC);
+        let christmas = datetime!(2023-12-25 12:00:00 UTC);
+        let second_christmas_day = datetime!(2023-12-26 12:00:00 UTC);
+
+        assert!(!calendar.is_business_day(new_years_day));
+        assert!(!calendar.is_business_day(revolution_1848_day));
+        assert!(!calendar.is_business_day(labour_day));
+        assert!(!calendar.is_business_day(national_holiday));
+        assert!(!calendar.is_business_day(revolution_1956_day));
+        assert!(!calendar.is_business_day(christmas));
+        assert!(!calendar.is_business_day(second_christmas_day));
+    }
+
+    // Test to verify if the is_business_day() method properly accounts for regular business days.
+    #[test]
+    fn test_is_regular_business_day() {
+        let calendar = Hungary;
+        let regular_day1 = datetime!(2024-03-07 12:00:00 UTC);
+        let regular_day2 = datetime!(2024-07-02 12:00:00 UTC);
+        let regular_day3 = datetime!(2024-12-11 12:00:00 UTC);
+
+        assert!(calendar.is_business_day(regular_day1));
+        assert!(calendar.is_business_day(regular_day2));
+        assert!(calendar.is_business_day(regular_day3));
+    }
+}

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -14,7 +14,7 @@ pub use crate::time::{
     calendars::{
         argentina::*, australia::*, austria::*, botswana::*, brazil::*, canada::*, chile::*,
         china::*, czech_republic::*, denmark::*, finland::*, france::*, germany::*, hong_kong::*,
-        united_kingdom::*, united_states::*,
+        hungary::*, united_kingdom::*, united_states::*,
     },
     constants::*,
     conventions::*,
@@ -63,6 +63,8 @@ pub mod calendars {
     pub mod germany;
     /// Hong Kong settlement calendar.
     pub mod hong_kong;
+    /// Hungary settlement calendar.
+    pub mod hungary;
     /// Calendar test module.
     mod tests;
     /// UK settlement calendar.


### PR DESCRIPTION
I decided to leave out the [Liberation Day](https://en.wikipedia.org/wiki/Liberation_Day_(Hungary)) since it was abolished before the stock exchange re-opened on 1990.
Similarly, the [1956 Revolution Day](https://en.wikipedia.org/wiki/Hungarian_Revolution_of_1956) only became a holiday after 1989.

Fixed extra whitespace.