### PR TITLE
Fix Gaussian statistics. Convention used here is self.variance = sigma^2

### DIFF
--- a/src/math/distributions/gaussian.rs
+++ b/src/math/distributions/gaussian.rs
@@ -83,7 +83,7 @@ impl Distribution for Gaussian {
 
         let i: Complex<f64> = Complex::i();
 
-        (i * self.mean * t - 0.5 * (self.variance).powi(2) * (t).powi(2)).exp()
+        (i * self.mean * t - 0.5 * self.variance * (t).powi(2)).exp()
     }
 
     /// Probability density function of the Gaussian distribution.
@@ -99,7 +99,7 @@ impl Distribution for Gaussian {
     fn pdf(&self, x: f64) -> f64 {
         assert!(self.variance > 0.0);
 
-        (-0.5 * ((x - self.mean) / self.variance).powi(2)).exp() / (2.0 * PI * self.variance).sqrt()
+        (-0.5 * ((x - self.mean).powi(2) / self.variance).exp()) / (2.0 * PI * self.variance).sqrt()
     }
 
     /// Probability mass function for the Gaussian distribution (continuous) is not defined.


### PR DESCRIPTION
The convention of what `self.variance` means in this struct is inconsistent. The struct definition defines it as "squared scale", as with the [Wikipedia page](https://en.wikipedia.org/wiki/Normal_distribution). The pdf with this convention is then defined 
$$f(x) = \frac{\exp( -\frac{(x-\mu)^2}{2\sigma^2})}{\sigma \sqrt{2\pi}}.$$
In particular, `self.variance` should not be squared in exponential. Similarly an inconsistency was found in the implementation of `Distribution::cf()`.

Note the old formulas passed tests because tests were run for $\sigma^2 = 1$, which is obviously constant upon taking powers.