### PR TITLE
Finite Difference Pricer using heap allocated vectors

### DIFF
--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -112,32 +112,19 @@ impl FiniteDifferencePricer {
     fn tridiagonal_matrix_multiply_vector(&self, A: &Vec<Vec<f64>>, v: Vec<f64>) -> Vec<f64> {
         
         let mut Av: Vec<f64> = Vec::new();
-        let mut value: f64;
-        let mut start: usize;
-        let mut end: usize;
 
         for i in 0..A.len() {
-            value = 0.0;
-            
             match i {
                 0 => {
-                    start = 0;
-                    end = 2;
+                    Av.push(A[0][0] * v[0] + A[0][1] * v[1])
                 },
                 n if n == A.len() - 1 => {
-                    start = n - 1;
-                    end = n + 1;
-                },
+                    Av.push(A[n][0] * v[n - 1] + A[n][1] * v[n])
+                }
                 _ => {
-                    start = i - 1;
-                    end = i + 2;
+                    Av.push(A[i][0] * v[i - 1] + A[i][1] * v[i] + A[i][2] * v[i + 1])
                 }
             }
-
-            for j in start..end {
-                value += A[i][j] * v[j]
-            }
-            Av.push(value)
         }
 
         Av

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -277,23 +277,23 @@ impl FiniteDifferencePricer {
     }
 
     fn boundary_condition_at_time_n(&self, price_steps: u32) -> Vec<f64> {
-        let u = (1..(price_steps)).map(|i| self.payoff(((i) as f64) * (2.0 * self.initial_price / (price_steps as f64)))).collect();
-        u
+        (1..(price_steps)).map(|i| self.payoff(((i) as f64) * (2.0 * self.initial_price / (price_steps as f64)))).collect()
     }
     
-    fn call_boundary(&self, t: u32, delta_t: f64) -> f64 {
-        2.0 * self.initial_price - self.strike_price * E.powf(-self.risk_free_rate * (((self.time_to_maturity as f64) / 365.0) - (t as f64 * delta_t)))
+    fn call_boundary(&self, t: u32, T: f64, delta_t: f64) -> f64 {
+        2.0 * self.initial_price - self.strike_price * E.powf(-(self.risk_free_rate * T) - (t as f64 * delta_t))
     }
 
-    fn put_boundary(&self, t: u32, delta_t: f64) -> f64 {
-        self.strike_price * E.powf(-self.risk_free_rate * (self.time_to_maturity as f64) / 365.0 - (t as f64 * delta_t))
+    fn put_boundary(&self, t: u32, T: f64, delta_t: f64) -> f64 {
+        self.strike_price * E.powf(-(self.risk_free_rate * T) - (t as f64 * delta_t))
     }
 
     /// Explicit method
     pub fn explicit(&self) -> f64 {
         let price_steps: u32 = self.price_steps();
         let time_steps: u32 = self.time_steps();
-        let delta_t: f64 = self.delta_t(time_steps);
+        let T: f64 = self.year_fraction();
+        let delta_t: f64 = T / (time_steps as f64);
     
         let tridiagonal_matrix = self.create_tridiagonal_matrix(
             self.sub_diagonal(delta_t / 2.0), 
@@ -309,10 +309,10 @@ impl FiniteDifferencePricer {
 
             match self.type_flag {
                 TypeFlag::Call => {
-                    u[(price_steps-2) as usize] += self.super_diagonal(delta_t / 2.0)((price_steps-1) as f64) * self.call_boundary(t, delta_t);
+                    u[(price_steps-2) as usize] += self.super_diagonal(delta_t / 2.0)((price_steps - 1) as f64) * self.call_boundary(t, T, delta_t);
                 }
                 TypeFlag::Put => {
-                    u[0] += self.sub_diagonal(delta_t / 2.0)(1.0) * self.put_boundary(t, delta_t);
+                    u[0] += self.sub_diagonal(delta_t / 2.0)(1.0) * self.put_boundary(t, T, delta_t);
                 }
             }
 

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -46,6 +46,8 @@ impl FiniteDifferencePricer {
         volatility: f64, 
         evaluation_date: Option<Date>,
         expiration_date: Date,
+        time_steps: u32,
+        price_steps: u32,
         type_flag: TypeFlag,
         exercise_flag: ExerciseFlag
     ) -> Self {
@@ -94,7 +96,9 @@ impl FiniteDifferencePricer {
             risk_free_rate, 
             volatility, 
             evaluation_date, 
-            expiration_date, 
+            expiration_date,
+            time_steps,
+            price_steps,
             type_flag,
             exercise_flag
         }

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -285,9 +285,8 @@ impl FiniteDifferencePricer {
                 }
             }
 
-            match self.exercise_flag {
-                ExerciseFlag::American => {u = self.american_time_stop_step(u, self.price_steps)}
-                _ => {}
+            if let ExerciseFlag::American = self.exercise_flag {
+                u = self.american_time_stop_step(u, self.price_steps);
             }
         }
 
@@ -324,9 +323,8 @@ impl FiniteDifferencePricer {
 
             u = self.matrix_multiply_vector(&inverse_matrix, u);
 
-            match self.exercise_flag {
-                ExerciseFlag::American => {u = self.american_time_stop_step(u, self.price_steps)}
-                _ => {}
+            if let ExerciseFlag::American = self.exercise_flag {
+                u = self.american_time_stop_step(u, self.price_steps);
             }
         }
 
@@ -372,9 +370,9 @@ impl FiniteDifferencePricer {
 
             u = self.matrix_multiply_vector(&inverse_past_matrix, u);
 
-            match self.exercise_flag {
-                ExerciseFlag::American => {u = self.american_time_stop_step(u, self.price_steps)}
-                _ => {}
+
+            if let ExerciseFlag::American = self.exercise_flag {
+                u = self.american_time_stop_step(u, self.price_steps);
             }
         }
 

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -80,9 +80,8 @@ impl FiniteDifferencePricer {
         
         match A[0].len() {
             n if n == v.len() => {
-                let mut value: f64;
                 for row in A {
-                    let mut value = 0.0;
+                    let mut value: f64 = 0.0;
                     for (a, b) in row.iter().zip(&v) {
                         value += a * b;
                     }
@@ -214,7 +213,7 @@ impl FiniteDifferencePricer {
             inverse_matrix.push(matrix_row.clone());
             matrix_row.clear()     
         }
-        
+
         inverse_matrix
 
     }

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -7,8 +7,10 @@
 //      - LICENSE-MIT.md
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use crate::instruments::options::option::{ExerciseFlag, TypeFlag};
 use std::f64::consts::E;
+use time::Date;
+use crate::time::{today, DayCountConvention};
+use crate::instruments::options::option::{ExerciseFlag, TypeFlag};
 
 /// Finite difference object
 pub struct FiniteDifferencePricer {

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -80,12 +80,12 @@ impl FiniteDifferencePricer {
         match A[0].len() {
             n if n == v.len() => {
                 let mut value: f64;
-                for i in 0..A.len() {
-                    value = 0.0;
-                    for j in 0..v.len() {
-                        value += A[i][j] * v[j]
+                for row in A {
+                    let mut value = 0.0;
+                    for (a, b) in row.iter().zip(&v) {
+                        value += a * b;
                     }
-                    Av.push(value)
+                    Av.push(value);
                 }
             },
             _ => {

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -73,7 +73,7 @@ impl FiniteDifferencePricer {
         }
     }
 
-    fn matrix_multiply_vector(&self, A: &Vec<Vec<f64>>, v: Vec<f64>) -> Vec<f64> {
+    fn matrix_multiply_vector(&self, A: &[Vec<f64>], v: Vec<f64>) -> Vec<f64> {
 
         let mut Av: Vec<f64> = Vec::new();
         

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -40,6 +40,7 @@ pub struct FiniteDifferencePricer {
 impl FiniteDifferencePricer {
 
     /// Constructor for FiniteDifferencePricer
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         initial_price: f64,
         strike_price: f64, 

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -52,43 +52,12 @@ impl FiniteDifferencePricer {
         exercise_flag: ExerciseFlag
     ) -> Self {
 
-        let mut variables_with_error: Vec<&str> = vec![];
-
-        if initial_price <= 0.0 {
-            variables_with_error.push("initial_price")
-        }
-        
-        if strike_price <= 0.0 {
-            variables_with_error.push("strike_price")
-        } 
-        
-        if risk_free_rate <= 0.0 {
-            variables_with_error.push("risk_free_rate")
-        } 
-
-        if volatility <= 0.0 {
-            variables_with_error.push("volatility")
-        } 
-
-        if variables_with_error.len() > 0 {
-            if variables_with_error.len() == 1 {
-                panic!("{} must be greater than 0!", variables_with_error[0])
-            } else if variables_with_error.len() == 2 {
-                panic!("{} and {} must both be greater than 0!", variables_with_error[0], variables_with_error[1])
-            } else {
-                let mut error_message: String = String::from("");
-                for (i, var) in variables_with_error.iter().enumerate() {
-                    if i == variables_with_error.len() - 1 {
-                        error_message += &format!(" and {} must all be greater than 0!", var)
-                    } else if i == variables_with_error.len() - 2 {
-                        error_message += &format!("{}", var)
-                    } else {
-                        error_message += &format!("{}, ", var)
-                    }
-                }
-                panic!("{}", error_message)
-            }
-        }
+        assert!(initial_price > 0.0, "initial_price must be greater than 0!");
+        assert!(strike_price > 0.0, "strike_price must be greater than 0!");
+        assert!(risk_free_rate > 0.0, "risk_free_rate must be greater than 0!");
+        assert!(volatility > 0.0, "volatility must be greater than 0!");
+        assert!(time_steps > 0, "time_steps must be greater than 0!");
+        assert!(price_steps > 0, "price_steps must be greater than 0!");
 
         Self {
             initial_price,

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -1,0 +1,499 @@
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// RustQuant: A Rust library for quantitative finance tools.
+// Copyright (C) 2023 https://github.com/avhz
+// Dual licensed under Apache 2.0 and MIT.
+// See:
+//      - LICENSE-APACHE.md
+//      - LICENSE-MIT.md
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+use crate::instruments::options::option::{ExerciseFlag, TypeFlag};
+use std::f64::consts::E;
+
+/// Finite difference object
+pub struct FiniteDifferencePricer {
+    /// Spot Price
+    pub initial_price: f64,
+    /// Strike price
+    pub strike_price: f64, 
+    /// Risk free rate
+    pub risk_free_rate: f64, 
+    /// Volatility
+    pub volatility: f64, 
+    /// Days until maturity
+    pub time_to_maturity: u16, 
+    /// Option Type
+    pub type_flag: TypeFlag,
+    /// Option Style
+    pub exercise_flag: ExerciseFlag,
+}
+
+impl FiniteDifferencePricer {
+
+    /// Constructor for FiniteDifferencePricer
+    pub fn new(
+        initial_price: f64,
+        strike_price: f64, 
+        risk_free_rate: f64, 
+        volatility: f64, 
+        time_to_maturity: u16, 
+        type_flag: TypeFlag,
+        exercise_flag: ExerciseFlag
+    ) -> Self {
+
+        let mut variables_with_error: Vec<&str> = vec![];
+
+        if initial_price <= 0.0 {
+            variables_with_error.push("initial_price")
+        }
+        
+        if strike_price <= 0.0 {
+            variables_with_error.push("strike_price")
+        } 
+        
+        if risk_free_rate <= 0.0 {
+            variables_with_error.push("risk_free_rate")
+        } 
+
+        if volatility <= 0.0 {
+            variables_with_error.push("volatility")
+        } 
+
+        if time_to_maturity <= 0 {
+            variables_with_error.push("time_to_maturity")
+        }
+
+        if variables_with_error.len() > 0 {
+            if variables_with_error.len() == 1 {
+                panic!("{} must be greater than 0!", variables_with_error[0])
+            } else if variables_with_error.len() == 2 {
+                panic!("{} and {} must both be greater than 0!", variables_with_error[0], variables_with_error[1])
+            } else {
+                let mut error_message: String = String::from("");
+                for (i, var) in variables_with_error.iter().enumerate() {
+                    if i == variables_with_error.len() - 1 {
+                        error_message += &format!(" and {} must all be greater than 0!", var)
+                    } else if i == variables_with_error.len() - 2 {
+                        error_message += &format!("{}", var)
+                    } else {
+                        error_message += &format!("{}, ", var)
+                    }
+                }
+                panic!("{}", error_message)
+            }
+        }
+
+        Self {
+            initial_price,
+            strike_price, 
+            risk_free_rate, 
+            volatility, 
+            time_to_maturity, 
+            type_flag,
+            exercise_flag
+        }
+    }
+
+    fn matrix_multiply_vector(&self, A: &Vec<Vec<f64>>, v: Vec<f64>) -> Vec<f64> {
+
+        let mut Av: Vec<f64> = Vec::new();
+        let mut value: f64;
+
+        for i in 0..A.len(){
+            value = 0.0;
+            for j in 0..v.len() {
+                value += A[i][j] * v[j]
+            }
+            Av.push(value)
+        }
+        Av
+    }
+
+    fn tridiagonal_matrix_multiply_vector(&self, A: &Vec<Vec<f64>>, v: Vec<f64>) -> Vec<f64> {
+        
+        let mut Av: Vec<f64> = Vec::new();
+        let mut value: f64;
+        let mut start: usize;
+        let mut end: usize;
+
+        for i in 0..A.len() {
+            value = 0.0;
+            
+            match i {
+                0 => {
+                    start = 0;
+                    end = 2;
+                },
+                n if n == A.len() - 1 => {
+                    start = n - 1;
+                    end = n + 1;
+                },
+                _ => {
+                    start = i - 1;
+                    end = i + 2;
+                }
+            }
+
+            for j in start..end {
+                value += A[i][j] * v[j]
+            }
+            Av.push(value)
+        }
+
+        Av
+    }
+
+    fn create_tridiagonal_matrix<A, B, C>(&self, sub_diagonal: A, diagonal: B, super_diagonal: C, price_steps: u32) -> Vec<Vec<f64>> 
+    where
+        A: Fn(f64) -> f64,
+        B: Fn(f64) -> f64,
+        C: Fn(f64) -> f64
+    {
+        let mut matrix_row: Vec<f64> = Vec::new();
+        let mut tridiagonal_matrix: Vec<Vec<f64>> = Vec::new();
+
+        for i in 1..(price_steps) {
+            if i > 1 {
+                for _j in 0..(i - 2) {
+                    matrix_row.push(0.0)    
+                }
+            }
+            
+            if i != 1 {
+                matrix_row.push(sub_diagonal(i as f64));
+            } 
+
+            matrix_row.push(diagonal(i as f64));
+            
+            if i != price_steps - 1 {
+                matrix_row.push(super_diagonal(i as f64));
+            }
+
+            for _j in i..(price_steps-2) {
+                matrix_row.push(0.0)    
+            }
+
+            tridiagonal_matrix.push(matrix_row.clone());
+            matrix_row.clear()
+        }
+
+        tridiagonal_matrix
+    }
+
+    fn invert_tridiagonal_matrix(&self, tridiagonal_matrix: Vec<Vec<f64>>) -> Vec<Vec<f64>> {
+        
+        let last = tridiagonal_matrix.len() - 1;
+        let mut theta: Vec<f64> = Vec::new();
+        theta.push(1.0);
+        theta.push(tridiagonal_matrix[0][0]);
+        
+        for i in 1..(tridiagonal_matrix.len()) {
+            theta.push(tridiagonal_matrix[i][i] * theta[i] 
+                - tridiagonal_matrix[i - 1][i] * tridiagonal_matrix[i][i - 1] * theta[i - 1]);
+        }
+
+        let mut phi: Vec<f64> = Vec::new();
+        phi.push(1.0);
+        phi.push(tridiagonal_matrix[last][last]);
+
+
+        for i in 1..(tridiagonal_matrix.len()) {
+            phi.push(
+                tridiagonal_matrix[last - i][last - i] * phi[i] 
+                - tridiagonal_matrix[last - i][last + 1 - i] * tridiagonal_matrix[last + 1 - i][last - i] * phi[i-1]
+            )
+        }
+
+        let theta_n = theta.pop().unwrap();
+        phi.pop();
+        phi.reverse();
+
+        let mut value: f64;
+        let mut inverse_matrix: Vec<Vec<f64>> = Vec::new();
+        let mut matrix_row: Vec<f64> = Vec::new();
+
+        for i in 0..tridiagonal_matrix.len() {
+            for j in 0..tridiagonal_matrix[0].len() {
+                value = (-1.0_f64).powi((i+j) as i32);
+                
+                if i < j {
+                    for k in i..j {
+                        value *= tridiagonal_matrix[k][k+1];
+                    }
+                    value *= theta[i] * phi[j] / theta_n;
+
+                } else if i == j {
+                    value *= theta[i] * phi[i] / theta_n
+                } else {
+                    for k in j..i {
+                        value *= tridiagonal_matrix[k+1][k]
+                    }
+                    value *= theta[j] * phi[i] / theta_n
+                }
+                matrix_row.push(value);
+            }
+            
+            inverse_matrix.push(matrix_row.clone());
+            matrix_row.clear()
+        }
+
+        inverse_matrix
+        
+    }
+
+    fn sub_diagonal(&self, scaler: f64) -> Box<dyn Fn(f64) -> f64 + '_> {
+        let function = move |m: f64| scaler * ((self.volatility.powi(2) * m.powi(2)) - (self.risk_free_rate * m));
+        Box::new(function)
+    }
+
+    fn diagonal(&self, scaler: f64) -> Box<dyn Fn(f64) -> f64 + '_> {
+        let function = move |m: f64| 1.0 + scaler * ((self.volatility.powi(2) * m.powi(2)) + self.risk_free_rate);
+        Box::new(function)
+    }
+
+    fn super_diagonal(&self, scaler: f64) -> Box<dyn Fn(f64) -> f64 + '_> {
+        let function = move |m: f64| scaler * ((self.volatility.powi(2)) * m.powi(2) + (self.risk_free_rate * m));
+        Box::new(function)
+    }
+
+    fn get_price_steps(&self) -> u32 {
+        (self.initial_price / 100.00) as u32 * 100 + 100
+    }
+
+    fn get_delta_t(&self, time_steps: u32) -> f64 {
+        self.time_to_maturity as f64 / ((365 * time_steps) as f64)
+    }
+
+    fn get_time_steps(&self) -> u32 {
+        ((self.time_to_maturity / 365) + 1) as u32 * 1000
+    }
+
+    fn payoff(&self, s: f64) -> f64 {
+        match self.type_flag {
+            TypeFlag::Call => (s - self.strike_price).max(0.0),
+            TypeFlag::Put => (self.strike_price - s).max(0.0)
+        }
+    }
+
+    fn american_time_stop_step(&self, u: Vec<f64>, price_steps: u32) -> Vec<f64> {
+        (0..(price_steps - 1)).map(|i: u32| u[i as usize].max(self.payoff((i+1) as f64 * (2.0 * self.initial_price) / (price_steps as f64)))).collect()
+    }
+
+    fn boundary_condition_at_time_n(&self, price_steps: u32) -> Vec<f64> {
+        let u = (1..(price_steps)).map(|i| self.payoff(((i) as f64) * (2.0 * self.initial_price / (price_steps as f64)))).collect();
+        u
+    }
+    
+    fn call_boundary(&self, t: u32, delta_t: f64) -> f64 {
+        2.0 * self.initial_price - self.strike_price * E.powf(-self.risk_free_rate * (((self.time_to_maturity as f64) / 365.0) - (t as f64 * delta_t)))
+    }
+
+    fn put_boundary(&self, t: u32, delta_t: f64) -> f64 {
+        self.strike_price * E.powf(-self.risk_free_rate * (self.time_to_maturity as f64) / 365.0 - (t as f64 * delta_t))
+    }
+
+    /// Explicit method
+    pub fn explicit(&self) -> f64 {
+        let price_steps: u32 = self.get_price_steps();
+        let time_steps: u32 = self.get_time_steps();
+        let delta_t: f64 = self.get_delta_t(time_steps);
+    
+        let tridiagonal_matrix = self.create_tridiagonal_matrix(
+            self.sub_diagonal(delta_t / 2.0), 
+            self.diagonal(- delta_t), 
+            self.super_diagonal(delta_t / 2.0), 
+            price_steps
+        );
+
+        let mut u: Vec<f64> = self.boundary_condition_at_time_n(price_steps);
+
+        for t in (1..time_steps).rev() {
+            u = self.tridiagonal_matrix_multiply_vector(&tridiagonal_matrix, u);
+
+            match self.type_flag {
+                TypeFlag::Call => {
+                    u[(price_steps-2) as usize] += self.super_diagonal(delta_t / 2.0)((price_steps-1) as f64) * self.call_boundary(t, delta_t);
+                }
+                TypeFlag::Put => {
+                    u[0] += self.sub_diagonal(delta_t / 2.0)(1.0) * self.put_boundary(t, delta_t);
+                }
+            }
+
+            match self.exercise_flag {
+                ExerciseFlag::American => {u = self.american_time_stop_step(u, price_steps)}
+                _ => {}
+            }
+        }
+
+        (u[((price_steps-1) / 2) as usize] * 10.0_f64.powi(2)).round() / 10.0_f64.powi(2)
+    }
+
+    /// Implicit method
+    pub fn implicit(&self) -> f64 {
+        let price_steps: u32 = self.get_price_steps();
+        let time_steps: u32 = self.get_time_steps();
+        let delta_t: f64 = self.get_delta_t(time_steps);
+        
+        let inverse_matrix = self.invert_tridiagonal_matrix(
+                self.create_tridiagonal_matrix(
+                    self.sub_diagonal(- delta_t / 2.0), 
+                    self.diagonal(delta_t), 
+                    self.super_diagonal(- delta_t / 2.0), 
+                    price_steps
+                )
+            );
+
+        let mut u: Vec<f64> = self.boundary_condition_at_time_n(price_steps);
+        
+        for t in (1..time_steps).rev() {
+            
+            match self.type_flag {
+                TypeFlag::Call => {
+                    u[(price_steps-2) as usize] -= self.super_diagonal(- delta_t / 2.0)((price_steps - 1) as f64) * self.call_boundary(t, delta_t);
+                }
+                TypeFlag::Put => {
+                    u[0] += self.sub_diagonal(delta_t / 2.0)(1.0) * self.put_boundary(t, delta_t);
+                }
+            }
+
+            u = self.matrix_multiply_vector(&inverse_matrix, u);
+
+            match self.exercise_flag {
+                ExerciseFlag::American => {u = self.american_time_stop_step(u, price_steps)}
+                _ => {}
+            }
+        }
+
+        (u[((price_steps-1) / 2) as usize] * 10.0_f64.powi(2)).round() / 10.0_f64.powi(2)
+    }
+
+    /// Crank-Nicolson method
+    pub fn crank_nicolson(&self) -> f64 {
+        let price_steps: u32 = self.get_price_steps();
+        let time_steps: u32 = self.get_time_steps();
+        let delta_t: f64 = self.get_delta_t(time_steps);
+
+        let inverse_past_matrix = self.invert_tridiagonal_matrix(
+            self.create_tridiagonal_matrix(
+                self.sub_diagonal(- delta_t / 4.0), 
+                self.diagonal(delta_t / 2.0), 
+                self.super_diagonal(- delta_t / 4.0),
+                price_steps
+            )
+        );
+        
+        let tridiagonal_future_matrix = self.create_tridiagonal_matrix(
+            self.sub_diagonal(delta_t / 4.0), 
+            self.diagonal(- delta_t / 2.0), 
+            self.super_diagonal(delta_t / 4.0),
+            price_steps
+        );
+
+        let mut u: Vec<f64> = self.boundary_condition_at_time_n(price_steps);
+
+        for t in (1..time_steps).rev() {
+            u = self.tridiagonal_matrix_multiply_vector(&tridiagonal_future_matrix, u);
+
+            match self.type_flag {
+                TypeFlag::Call => {
+                    u[(price_steps-2) as usize] += self.super_diagonal(delta_t / 4.0)((price_steps-1) as f64) * (self.call_boundary(t + 1, delta_t) - self.call_boundary(t, delta_t))
+                }
+                TypeFlag::Put => {
+                    u[0] += self.sub_diagonal(delta_t / 4.0)(1.0) * (self.put_boundary(t + 1, delta_t) - self.put_boundary(t, delta_t))
+                }
+            }
+
+            u = self.matrix_multiply_vector(&inverse_past_matrix, u);
+
+            match self.exercise_flag {
+                ExerciseFlag::American => {u = self.american_time_stop_step(u, price_steps)}
+                _ => {}
+            }
+        }
+
+        (u[((price_steps-1) / 2) as usize] * 10.0_f64.powi(2)).round() / 10.0_f64.powi(2)
+    }
+}
+
+#[cfg(test)]
+mod tests_finite_difference_pricer {
+    use super::*;
+    use crate::assert_approx_equal;
+    use crate::RUSTQUANT_EPSILON;
+
+    #[test]
+    fn european_call_option() {
+
+        let finite_difference_obj = FiniteDifferencePricer::new(
+            10.11,
+            5.43,
+            0.1,
+            0.3,
+            50,
+            TypeFlag::Call,
+            ExerciseFlag::European,
+        );
+
+        let answer = 4.75;
+        assert_approx_equal!(finite_difference_obj.explicit(), answer, RUSTQUANT_EPSILON);
+        assert_approx_equal!(finite_difference_obj.implicit(), answer, RUSTQUANT_EPSILON);
+        assert_approx_equal!(finite_difference_obj.crank_nicolson(), answer, RUSTQUANT_EPSILON);
+    }
+
+    #[test]
+    fn european_put_option() {
+
+        let finite_difference_obj = FiniteDifferencePricer::new(
+            101.22,
+            137.89,
+            0.12,
+            0.25,
+            14,
+            TypeFlag::Put,
+            ExerciseFlag::European,
+        );
+
+        let answer = 36.04;
+        assert_approx_equal!(finite_difference_obj.explicit(), answer, RUSTQUANT_EPSILON);
+        assert_approx_equal!(finite_difference_obj.implicit(), answer, RUSTQUANT_EPSILON);
+        assert_approx_equal!(finite_difference_obj.crank_nicolson(), answer, RUSTQUANT_EPSILON);
+    }
+
+    #[test]
+    fn american_call_option() {
+
+        let finite_difference_obj = FiniteDifferencePricer::new(
+            150.66,
+            133.4, 
+            0.01, 
+            0.2, 
+            365, 
+            TypeFlag::Call,
+            ExerciseFlag::American,
+        );
+
+        let answer = 22.9;
+        assert_approx_equal!(finite_difference_obj.explicit(), answer, RUSTQUANT_EPSILON);
+        assert_approx_equal!(finite_difference_obj.implicit(), answer, RUSTQUANT_EPSILON);
+        assert_approx_equal!(finite_difference_obj.crank_nicolson(), answer, RUSTQUANT_EPSILON);
+    }
+
+    #[test]
+    fn american_put_option() {
+
+        let finite_difference_obj = FiniteDifferencePricer::new(
+            3.22,
+            12.87, 
+            0.02, 
+            0.2, 
+            365, 
+            TypeFlag::Put,
+            ExerciseFlag::American,
+        );
+
+        let answer = 9.65;
+        assert_approx_equal!(finite_difference_obj.explicit(), answer, RUSTQUANT_EPSILON);
+        assert_approx_equal!(finite_difference_obj.implicit(), answer, RUSTQUANT_EPSILON);
+        assert_approx_equal!(finite_difference_obj.crank_nicolson(), answer, RUSTQUANT_EPSILON);
+    }
+}

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -403,9 +403,28 @@ mod tests_finite_difference_pricer {
     use time::Duration;
 
     #[test]
-    fn european_call_option() {
+    fn european_call_option_explicit() {
 
-        let finite_difference_obj = FiniteDifferencePricer::new(
+        let finite_difference_obj: FiniteDifferencePricer = FiniteDifferencePricer::new(
+            10.11,
+            5.43,
+            0.1,
+            0.3,
+            None,
+            today() + Duration::days(50),
+            1000,
+            101,
+            TypeFlag::Call,
+            ExerciseFlag::European,
+        );
+
+        assert_approx_equal!(finite_difference_obj.explicit(), 4.75360326, RUSTQUANT_EPSILON);
+    }
+
+    #[test]
+    fn european_call_option_implicit() {
+
+        let finite_difference_obj: FiniteDifferencePricer = FiniteDifferencePricer::new(
             10.11,
             5.43,
             0.1,
@@ -418,16 +437,32 @@ mod tests_finite_difference_pricer {
             ExerciseFlag::European,
         );
 
-        let answer: f64 = 4.75;
-        assert_approx_equal!(finite_difference_obj.explicit(), answer, RUSTQUANT_EPSILON);
-        assert_approx_equal!(finite_difference_obj.implicit(), answer, RUSTQUANT_EPSILON);
-        assert_approx_equal!(finite_difference_obj.crank_nicolson(), answer, RUSTQUANT_EPSILON);
+        assert_approx_equal!(finite_difference_obj.implicit(), 4.75360226, RUSTQUANT_EPSILON);
     }
 
     #[test]
-    fn european_put_option() {
+    fn european_call_option_crank_nicolson() {
 
-        let finite_difference_obj = FiniteDifferencePricer::new(
+        let finite_difference_obj: FiniteDifferencePricer = FiniteDifferencePricer::new(
+            10.11,
+            5.43,
+            0.1,
+            0.3,
+            None,
+            today() + Duration::days(50),
+            1000,
+            100,
+            TypeFlag::Call,
+            ExerciseFlag::European,
+        );
+
+        assert_approx_equal!(finite_difference_obj.crank_nicolson(), 4.75360273, RUSTQUANT_EPSILON);
+    }
+
+    #[test]
+    fn european_put_option_explicit() {
+
+        let finite_difference_obj: FiniteDifferencePricer = FiniteDifferencePricer::new(
             101.22,
             137.89,
             0.12,
@@ -440,16 +475,51 @@ mod tests_finite_difference_pricer {
             ExerciseFlag::European,
         );
 
-        let answer: f64 = 36.04;
-        assert_approx_equal!(finite_difference_obj.explicit(), answer, RUSTQUANT_EPSILON);
-        assert_approx_equal!(finite_difference_obj.implicit(), answer, RUSTQUANT_EPSILON);
-        assert_approx_equal!(finite_difference_obj.crank_nicolson(), answer, RUSTQUANT_EPSILON);
+        assert_approx_equal!(finite_difference_obj.explicit(), 36.03914133, RUSTQUANT_EPSILON);
     }
 
     #[test]
-    fn american_call_option() {
+    fn european_put_option_implicit() {
 
-        let finite_difference_obj = FiniteDifferencePricer::new(
+        let finite_difference_obj: FiniteDifferencePricer = FiniteDifferencePricer::new(
+            101.22,
+            137.89,
+            0.12,
+            0.25,
+            None,
+            today() + Duration::days(14),
+            1000,
+            101,
+            TypeFlag::Put,
+            ExerciseFlag::European,
+        );
+
+        assert_approx_equal!(finite_difference_obj.implicit(), 36.03914422, RUSTQUANT_EPSILON);
+    }
+
+    #[test]
+    fn european_put_option_crank_nicolson() {
+
+        let finite_difference_obj: FiniteDifferencePricer = FiniteDifferencePricer::new(
+            101.22,
+            137.89,
+            0.12,
+            0.25,
+            None,
+            today() + Duration::days(14),
+            1000,
+            100,
+            TypeFlag::Put,
+            ExerciseFlag::European,
+        );
+
+        assert_approx_equal!(finite_difference_obj.crank_nicolson(), 36.03914277, RUSTQUANT_EPSILON);
+    }
+
+    #[test]
+    fn american_call_option_explicit() {
+
+        let finite_difference_obj: FiniteDifferencePricer = FiniteDifferencePricer::new(
             15.66,
             3.4, 
             0.01, 
@@ -462,14 +532,87 @@ mod tests_finite_difference_pricer {
             ExerciseFlag::American,
         );
 
-        let answer: f64 = 12.29;
-        assert_approx_equal!(finite_difference_obj.explicit(), answer, RUSTQUANT_EPSILON);
-        assert_approx_equal!(finite_difference_obj.implicit(), answer, RUSTQUANT_EPSILON);
-        assert_approx_equal!(finite_difference_obj.crank_nicolson(), answer, RUSTQUANT_EPSILON);
+        assert_approx_equal!(finite_difference_obj.explicit(), 12.29460234, RUSTQUANT_EPSILON);
     }
 
     #[test]
-    fn american_put_option() {
+    fn american_call_option_implicit() {
+
+        let finite_difference_obj: FiniteDifferencePricer = FiniteDifferencePricer::new(
+            15.66,
+            3.4, 
+            0.01, 
+            0.2, 
+            None,
+            today() + Duration::days(365),
+            1000,
+            100,
+            TypeFlag::Call,
+            ExerciseFlag::American,
+        );
+
+        assert_approx_equal!(finite_difference_obj.implicit(), 12.2946257, RUSTQUANT_EPSILON);
+    }
+
+    #[test]
+    fn american_call_option_crank_nicolson() {
+
+        let finite_difference_obj: FiniteDifferencePricer = FiniteDifferencePricer::new(
+            15.66,
+            3.4, 
+            0.01, 
+            0.2, 
+            None,
+            today() + Duration::days(365),
+            1000,
+            100,
+            TypeFlag::Call,
+            ExerciseFlag::American,
+        );
+
+        assert_approx_equal!(finite_difference_obj.crank_nicolson(), 12.29372857, RUSTQUANT_EPSILON);
+    }
+
+    #[test]
+    fn american_put_option_explicit() {
+
+        let finite_difference_obj: FiniteDifferencePricer = FiniteDifferencePricer::new(
+            3.22,
+            12.87, 
+            0.02, 
+            0.2, 
+            None,
+            today() + Duration::days(365),
+            1000,
+            101,
+            TypeFlag::Put,
+            ExerciseFlag::American,
+        );
+
+        assert_approx_equal!(finite_difference_obj.explicit(), 9.65, RUSTQUANT_EPSILON);
+    }
+
+    #[test]
+    fn american_put_option_implicit() {
+
+        let finite_difference_obj: FiniteDifferencePricer = FiniteDifferencePricer::new(
+            3.22,
+            12.87, 
+            0.02, 
+            0.2, 
+            None,
+            today() + Duration::days(365),
+            1000,
+            101,
+            TypeFlag::Put,
+            ExerciseFlag::American,
+        );
+
+        assert_approx_equal!(finite_difference_obj.implicit(), 9.65, RUSTQUANT_EPSILON);
+    }
+
+    #[test]
+    fn american_put_option_crank_nicolson() {
 
         let finite_difference_obj = FiniteDifferencePricer::new(
             3.22,
@@ -484,9 +627,6 @@ mod tests_finite_difference_pricer {
             ExerciseFlag::American,
         );
 
-        let answer: f64 = 9.65;
-        assert_approx_equal!(finite_difference_obj.explicit(), answer, RUSTQUANT_EPSILON);
-        assert_approx_equal!(finite_difference_obj.implicit(), answer, RUSTQUANT_EPSILON);
-        assert_approx_equal!(finite_difference_obj.crank_nicolson(), answer, RUSTQUANT_EPSILON);
+        assert_approx_equal!(finite_difference_obj.crank_nicolson(), 9.65, RUSTQUANT_EPSILON);
     }
 }

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -26,6 +26,10 @@ pub struct FiniteDifferencePricer {
     pub evaluation_date: Option<Date>,
     /// Maturity date
     pub expiration_date: Date,
+    /// Time steps
+    pub time_steps: u32,
+    /// Price steps
+    pub price_steps: u32,
     /// Option Type
     pub type_flag: TypeFlag,
     /// Option Style

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -22,8 +22,10 @@ pub struct FiniteDifferencePricer {
     pub risk_free_rate: f64, 
     /// Volatility
     pub volatility: f64, 
-    /// Days until maturity
-    pub time_to_maturity: u16, 
+    /// Evaluation date
+    pub evaluation_date: Option<Date>,
+    /// Maturity date
+    pub expiration_date: Date,
     /// Option Type
     pub type_flag: TypeFlag,
     /// Option Style

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -254,12 +254,15 @@ impl FiniteDifferencePricer {
         (self.initial_price / 100.00) as u32 * 100 + 100
     }
 
-    fn delta_t(&self, time_steps: u32) -> f64 {
-        self.time_to_maturity as f64 / ((365 * time_steps) as f64)
+    fn year_fraction(&self) -> f64 {
+        DayCountConvention::default().day_count_factor(
+            self.evaluation_date.unwrap_or(today()),
+            self.expiration_date,
+        )
     }
 
     fn time_steps(&self) -> u32 {
-        ((self.time_to_maturity / 365) + 1) as u32 * 1000
+        ((((self.expiration_date - self.evaluation_date.unwrap_or(today())).whole_days() / 365) + 1) * 1000) as u32
     }
 
     fn payoff(&self, s: f64) -> f64 {

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -190,32 +190,32 @@ impl FiniteDifferencePricer {
                 value = (-1.0_f64).powi((i+j) as i32);
                 
                 match i.cmp(&j) {
-                Ordering::Less => {
-                    for item in &tridiagonal_matrix[i..j] {
-                        value *= item.last().unwrap()
-                    }
-                    value *= theta[i] * phi[j] / theta_n;
+                    Ordering::Less => {
+                        for item in &tridiagonal_matrix[i..j] {
+                            value *= item.last().unwrap()
+                        }
+                        value *= theta[i] * phi[j] / theta_n;
 
-                },
-                Ordering::Equal => {
-                    value *= theta[i] * phi[i] / theta_n
-                },
-                
-                Ordering::Greater => {
-                    for item in &tridiagonal_matrix[(j+1)..(i+1)] {
-                        value *= item.first().unwrap()
-                    }
+                    },
+                    Ordering::Equal => {
+                        value *= theta[i] * phi[i] / theta_n
+                    },
+                    
+                    Ordering::Greater => {
+                        for item in &tridiagonal_matrix[(j+1)..(i+1)] {
+                            value *= item.first().unwrap()
+                        }
 
-                    value *= theta[j] * phi[i] / theta_n
+                        value *= theta[j] * phi[i] / theta_n
+                    }
                 }
-            }
-            matrix_row.push(value);
-            
-        }   
-        inverse_matrix.push(matrix_row.clone());
-        matrix_row.clear()     
-    }
-    inverse_matrix
+                matrix_row.push(value);
+            }   
+            inverse_matrix.push(matrix_row.clone());
+            matrix_row.clear()     
+        }
+        
+        inverse_matrix
 
     }
 

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -258,19 +258,11 @@ impl FiniteDifferencePricer {
         Box::new(function)
     }
 
-    fn price_steps(&self) -> u32 {
-        (self.initial_price / 100.00) as u32 * 100 + 100
-    }
-
     fn year_fraction(&self) -> f64 {
         DayCountConvention::default().day_count_factor(
             self.evaluation_date.unwrap_or(today()),
             self.expiration_date,
         )
-    }
-
-    fn time_steps(&self) -> u32 {
-        ((((self.expiration_date - self.evaluation_date.unwrap_or(today())).whole_days() / 365) + 1) * 1000) as u32
     }
 
     fn payoff(&self, s: f64) -> f64 {

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -97,77 +97,38 @@ impl FiniteDifferencePricer {
     fn matrix_multiply_vector(&self, A: &Vec<Vec<f64>>, v: Vec<f64>) -> Vec<f64> {
 
         let mut Av: Vec<f64> = Vec::new();
-        let mut value: f64;
-
-        for i in 0..A.len(){
-            value = 0.0;
-            for j in 0..v.len() {
-                value += A[i][j] * v[j]
-            }
-            Av.push(value)
-        }
-        Av
-    }
-
-    fn trimmed_tridiagonal_matrix_multiply_vector(&self, A: &Vec<Vec<f64>>, v: Vec<f64>) -> Vec<f64> {
         
-        let mut Av: Vec<f64> = Vec::new();
-
-        for i in 0..A.len() {
-            match i {
-                0 => {
-                    Av.push(A[0][0] * v[0] + A[0][1] * v[1])
-                },
-                n if n == A.len() - 1 => {
-                    Av.push(A[n][0] * v[n - 1] + A[n][1] * v[n])
+        match A[0].len() {
+            n if n == v.len() => {
+                let mut value: f64;
+                for i in 0..A.len() {
+                    value = 0.0;
+                    for j in 0..v.len() {
+                        value += A[i][j] * v[j]
+                    }
+                    Av.push(value)
                 }
-                _ => {
-                    Av.push(A[i][0] * v[i - 1] + A[i][1] * v[i] + A[i][2] * v[i + 1])
+            },
+            _ => {
+                for i in 0..A.len() {
+                    match i {
+                        0 => {
+                            Av.push(A[0][0] * v[0] + A[0][1] * v[1])
+                        },
+                        n if n == A.len() - 1 => {
+                            Av.push(A[n][0] * v[n - 1] + A[n][1] * v[n])
+                        }
+                        _ => {
+                            Av.push(A[i][0] * v[i - 1] + A[i][1] * v[i] + A[i][2] * v[i + 1])
+                        }
+                    }
                 }
             }
         }
-
         Av
     }
-
+    
     fn create_tridiagonal_matrix<A, B, C>(&self, sub_diagonal: A, diagonal: B, super_diagonal: C, price_steps: u32) -> Vec<Vec<f64>> 
-    where
-        A: Fn(f64) -> f64,
-        B: Fn(f64) -> f64,
-        C: Fn(f64) -> f64
-    {
-        let mut matrix_row: Vec<f64> = Vec::new();
-        let mut tridiagonal_matrix: Vec<Vec<f64>> = Vec::new();
-
-        for i in 1..(price_steps) {
-            if i > 1 {
-                for _j in 0..(i - 2) {
-                    matrix_row.push(0.0)    
-                }
-            }
-            
-            if i != 1 {
-                matrix_row.push(sub_diagonal(i as f64));
-            } 
-
-            matrix_row.push(diagonal(i as f64));
-            
-            if i != price_steps - 1 {
-                matrix_row.push(super_diagonal(i as f64));
-            }
-
-            for _j in i..(price_steps-2) {
-                matrix_row.push(0.0)    
-            }
-
-            tridiagonal_matrix.push(matrix_row.clone());
-            matrix_row.clear()
-        }
-
-        tridiagonal_matrix
-    }
-
-    fn create_trimmed_tridiagonal_matrix<A, B, C>(&self, sub_diagonal: A, diagonal: B, super_diagonal: C, price_steps: u32) -> Vec<Vec<f64>> 
     where
         A: Fn(f64) -> f64,
         B: Fn(f64) -> f64,

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -276,7 +276,8 @@ impl FiniteDifferencePricer {
 
             match self.type_flag {
                 TypeFlag::Call => {
-                    u[(self.price_steps-2) as usize] += self.super_diagonal(delta_t / 2.0)((self.price_steps - 1) as f64) * self.call_boundary(t, T, delta_t);
+                    u[(self.price_steps-2) as usize] += self.super_diagonal(delta_t / 2.0)((self.price_steps - 1) as f64) 
+                    * self.call_boundary(t, T, delta_t);
                 }
                 TypeFlag::Put => {
                     u[0] += self.sub_diagonal(delta_t / 2.0)(1.0) * self.put_boundary(t, T, delta_t);
@@ -312,7 +313,8 @@ impl FiniteDifferencePricer {
             
             match self.type_flag {
                 TypeFlag::Call => {
-                    u[(self.price_steps-2) as usize] -= self.super_diagonal(- delta_t / 2.0)((self.price_steps - 1) as f64) * self.call_boundary(t, T, delta_t);
+                    u[(self.price_steps-2) as usize] -= self.super_diagonal(- delta_t / 2.0)((self.price_steps - 1) as f64) 
+                    * self.call_boundary(t, T, delta_t);
                 }
                 TypeFlag::Put => {
                     u[0] += self.sub_diagonal(delta_t / 2.0)(1.0) * self.put_boundary(t, T, delta_t);
@@ -358,10 +360,12 @@ impl FiniteDifferencePricer {
 
             match self.type_flag {
                 TypeFlag::Call => {
-                    u[(self.price_steps-2) as usize] += self.super_diagonal(delta_t / 4.0)((self.price_steps - 1) as f64) * (self.call_boundary(t + 1, T, delta_t) - self.call_boundary(t, T, delta_t))
+                    u[(self.price_steps-2) as usize] += self.super_diagonal(delta_t / 4.0)((self.price_steps - 1) as f64) 
+                    * (self.call_boundary(t + 1, T, delta_t) - self.call_boundary(t, T, delta_t))
                 }
                 TypeFlag::Put => {
-                    u[0] += self.sub_diagonal(delta_t / 4.0)(1.0) * (self.put_boundary(t + 1, T, delta_t) - self.put_boundary(t, T, delta_t))
+                    u[0] += self.sub_diagonal(delta_t / 4.0)(1.0) 
+                    * (self.put_boundary(t + 1, T, delta_t) - self.put_boundary(t, T, delta_t))
                 }
             }
 

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -438,7 +438,7 @@ mod tests_finite_difference_pricer {
 
         let finite_difference_obj = FiniteDifferencePricer::new(
             15.66,
-            13.4, 
+            3.4, 
             0.01, 
             0.2, 
             None,
@@ -449,7 +449,7 @@ mod tests_finite_difference_pricer {
             ExerciseFlag::American,
         );
 
-        let answer: f64 = 2.72;
+        let answer: f64 = 12.29;
         assert_approx_equal!(finite_difference_obj.explicit(), answer, RUSTQUANT_EPSILON);
         assert_approx_equal!(finite_difference_obj.implicit(), answer, RUSTQUANT_EPSILON);
         assert_approx_equal!(finite_difference_obj.crank_nicolson(), answer, RUSTQUANT_EPSILON);

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -329,7 +329,8 @@ impl FiniteDifferencePricer {
     pub fn implicit(&self) -> f64 {
         let price_steps: u32 = self.price_steps();
         let time_steps: u32 = self.time_steps();
-        let delta_t: f64 = self.delta_t(time_steps);
+        let T: f64 = self.year_fraction();
+        let delta_t: f64 = T / (time_steps as f64);
         
         let inverse_matrix = self.invert_tridiagonal_matrix(
                 self.create_tridiagonal_matrix(
@@ -338,7 +339,7 @@ impl FiniteDifferencePricer {
                     self.super_diagonal(- delta_t / 2.0), 
                     price_steps
                 )
-            );
+            ); 
 
         let mut u: Vec<f64> = self.boundary_condition_at_time_n(price_steps);
         
@@ -346,10 +347,10 @@ impl FiniteDifferencePricer {
             
             match self.type_flag {
                 TypeFlag::Call => {
-                    u[(price_steps-2) as usize] -= self.super_diagonal(- delta_t / 2.0)((price_steps - 1) as f64) * self.call_boundary(t, delta_t);
+                    u[(price_steps-2) as usize] -= self.super_diagonal(- delta_t / 2.0)((price_steps - 1) as f64) * self.call_boundary(t, T, delta_t);
                 }
                 TypeFlag::Put => {
-                    u[0] += self.sub_diagonal(delta_t / 2.0)(1.0) * self.put_boundary(t, delta_t);
+                    u[0] += self.sub_diagonal(delta_t / 2.0)(1.0) * self.put_boundary(t, T, delta_t);
                 }
             }
 
@@ -368,7 +369,8 @@ impl FiniteDifferencePricer {
     pub fn crank_nicolson(&self) -> f64 {
         let price_steps: u32 = self.price_steps();
         let time_steps: u32 = self.time_steps();
-        let delta_t: f64 = self.delta_t(time_steps);
+        let T: f64 = self.year_fraction();
+        let delta_t: f64 = T / (time_steps as f64);
 
         let inverse_past_matrix = self.invert_tridiagonal_matrix(
             self.create_tridiagonal_matrix(
@@ -393,10 +395,10 @@ impl FiniteDifferencePricer {
 
             match self.type_flag {
                 TypeFlag::Call => {
-                    u[(price_steps-2) as usize] += self.super_diagonal(delta_t / 4.0)((price_steps-1) as f64) * (self.call_boundary(t + 1, delta_t) - self.call_boundary(t, delta_t))
+                    u[(price_steps-2) as usize] += self.super_diagonal(delta_t / 4.0)((price_steps - 1) as f64) * (self.call_boundary(t + 1, T, delta_t) - self.call_boundary(t, T, delta_t))
                 }
                 TypeFlag::Put => {
-                    u[0] += self.sub_diagonal(delta_t / 4.0)(1.0) * (self.put_boundary(t + 1, delta_t) - self.put_boundary(t, delta_t))
+                    u[0] += self.sub_diagonal(delta_t / 4.0)(1.0) * (self.put_boundary(t + 1, T, delta_t) - self.put_boundary(t, T, delta_t))
                 }
             }
 

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -78,11 +78,12 @@ impl FiniteDifferencePricer {
     fn matrix_multiply_vector(&self, A: &[Vec<f64>], v: Vec<f64>) -> Vec<f64> {
 
         let mut Av: Vec<f64> = Vec::new();
+        let mut value: f64;
         
         match A[0].len() {
             n if n == v.len() => {
                 for row in A {
-                    let mut value: f64 = 0.0;
+                    value = 0.0;
                     for (a, b) in row.iter().zip(&v) {
                         value += a * b;
                     }

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -256,15 +256,15 @@ impl FiniteDifferencePricer {
         Box::new(function)
     }
 
-    fn get_price_steps(&self) -> u32 {
+    fn price_steps(&self) -> u32 {
         (self.initial_price / 100.00) as u32 * 100 + 100
     }
 
-    fn get_delta_t(&self, time_steps: u32) -> f64 {
+    fn delta_t(&self, time_steps: u32) -> f64 {
         self.time_to_maturity as f64 / ((365 * time_steps) as f64)
     }
 
-    fn get_time_steps(&self) -> u32 {
+    fn time_steps(&self) -> u32 {
         ((self.time_to_maturity / 365) + 1) as u32 * 1000
     }
 
@@ -294,9 +294,9 @@ impl FiniteDifferencePricer {
 
     /// Explicit method
     pub fn explicit(&self) -> f64 {
-        let price_steps: u32 = self.get_price_steps();
-        let time_steps: u32 = self.get_time_steps();
-        let delta_t: f64 = self.get_delta_t(time_steps);
+        let price_steps: u32 = self.price_steps();
+        let time_steps: u32 = self.time_steps();
+        let delta_t: f64 = self.delta_t(time_steps);
     
         let tridiagonal_matrix = self.create_tridiagonal_matrix(
             self.sub_diagonal(delta_t / 2.0), 
@@ -330,9 +330,9 @@ impl FiniteDifferencePricer {
 
     /// Implicit method
     pub fn implicit(&self) -> f64 {
-        let price_steps: u32 = self.get_price_steps();
-        let time_steps: u32 = self.get_time_steps();
-        let delta_t: f64 = self.get_delta_t(time_steps);
+        let price_steps: u32 = self.price_steps();
+        let time_steps: u32 = self.time_steps();
+        let delta_t: f64 = self.delta_t(time_steps);
         
         let inverse_matrix = self.invert_tridiagonal_matrix(
                 self.create_tridiagonal_matrix(
@@ -369,9 +369,9 @@ impl FiniteDifferencePricer {
 
     /// Crank-Nicolson method
     pub fn crank_nicolson(&self) -> f64 {
-        let price_steps: u32 = self.get_price_steps();
-        let time_steps: u32 = self.get_time_steps();
-        let delta_t: f64 = self.get_delta_t(time_steps);
+        let price_steps: u32 = self.price_steps();
+        let time_steps: u32 = self.time_steps();
+        let delta_t: f64 = self.delta_t(time_steps);
 
         let inverse_past_matrix = self.invert_tridiagonal_matrix(
             self.create_tridiagonal_matrix(

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -295,7 +295,7 @@ impl FiniteDifferencePricer {
             }
         }
 
-        (u[((self.price_steps-1) / 2) as usize] * 10.0_f64.powi(2)).round() / 10.0_f64.powi(2)
+        u[((self.price_steps - 1) / 2) as usize]
     }
 
     /// Implicit method
@@ -333,7 +333,7 @@ impl FiniteDifferencePricer {
             }
         }
 
-        (u[((self.price_steps-1) / 2) as usize] * 10.0_f64.powi(2)).round() / 10.0_f64.powi(2)
+        u[((self.price_steps - 1) / 2) as usize]
     }
 
     /// Crank-Nicolson method
@@ -381,7 +381,7 @@ impl FiniteDifferencePricer {
             }
         }
 
-        (u[((self.price_steps-1) / 2) as usize] * 10.0_f64.powi(2)).round() / 10.0_f64.powi(2)
+        u[((self.price_steps - 1) / 2) as usize]
     }
 }
 

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -104,6 +104,7 @@ impl FiniteDifferencePricer {
                 }
             }
         }
+        
         Av
     }
     
@@ -396,12 +397,15 @@ mod tests_finite_difference_pricer {
             5.43,
             0.1,
             0.3,
-            50,
+            None,
+            today() + Duration::days(50),
+            1000,
+            100,
             TypeFlag::Call,
             ExerciseFlag::European,
         );
 
-        let answer = 4.75;
+        let answer: f64 = 4.75;
         assert_approx_equal!(finite_difference_obj.explicit(), answer, RUSTQUANT_EPSILON);
         assert_approx_equal!(finite_difference_obj.implicit(), answer, RUSTQUANT_EPSILON);
         assert_approx_equal!(finite_difference_obj.crank_nicolson(), answer, RUSTQUANT_EPSILON);
@@ -415,12 +419,15 @@ mod tests_finite_difference_pricer {
             137.89,
             0.12,
             0.25,
-            14,
+            None,
+            today() + Duration::days(14),
+            1000,
+            100,
             TypeFlag::Put,
             ExerciseFlag::European,
         );
 
-        let answer = 36.04;
+        let answer: f64 = 36.04;
         assert_approx_equal!(finite_difference_obj.explicit(), answer, RUSTQUANT_EPSILON);
         assert_approx_equal!(finite_difference_obj.implicit(), answer, RUSTQUANT_EPSILON);
         assert_approx_equal!(finite_difference_obj.crank_nicolson(), answer, RUSTQUANT_EPSILON);
@@ -430,16 +437,19 @@ mod tests_finite_difference_pricer {
     fn american_call_option() {
 
         let finite_difference_obj = FiniteDifferencePricer::new(
-            150.66,
-            133.4, 
+            15.66,
+            13.4, 
             0.01, 
             0.2, 
-            365, 
+            None,
+            today() + Duration::days(365),
+            1000,
+            100,
             TypeFlag::Call,
             ExerciseFlag::American,
         );
 
-        let answer = 22.9;
+        let answer: f64 = 2.72;
         assert_approx_equal!(finite_difference_obj.explicit(), answer, RUSTQUANT_EPSILON);
         assert_approx_equal!(finite_difference_obj.implicit(), answer, RUSTQUANT_EPSILON);
         assert_approx_equal!(finite_difference_obj.crank_nicolson(), answer, RUSTQUANT_EPSILON);
@@ -453,12 +463,15 @@ mod tests_finite_difference_pricer {
             12.87, 
             0.02, 
             0.2, 
-            365, 
+            None,
+            today() + Duration::days(365),
+            1000,
+            100,
             TypeFlag::Put,
             ExerciseFlag::American,
         );
 
-        let answer = 9.65;
+        let answer: f64 = 9.65;
         assert_approx_equal!(finite_difference_obj.explicit(), answer, RUSTQUANT_EPSILON);
         assert_approx_equal!(finite_difference_obj.implicit(), answer, RUSTQUANT_EPSILON);
         assert_approx_equal!(finite_difference_obj.crank_nicolson(), answer, RUSTQUANT_EPSILON);

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -180,6 +180,34 @@ impl FiniteDifferencePricer {
         tridiagonal_matrix
     }
 
+    fn create_tridiagonal_matrix_without_zeros<A, B, C>(&self, sub_diagonal: A, diagonal: B, super_diagonal: C, price_steps: u32) -> Vec<Vec<f64>> 
+    where
+        A: Fn(f64) -> f64,
+        B: Fn(f64) -> f64,
+        C: Fn(f64) -> f64
+    {
+        let mut matrix_row: Vec<f64> = Vec::new();
+        let mut tridiagonal_matrix: Vec<Vec<f64>> = Vec::new();
+
+        for i in 1..(price_steps) {
+            
+            if i != 1 {
+                matrix_row.push(sub_diagonal(i as f64));
+            } 
+
+            matrix_row.push(diagonal(i as f64));
+            
+            if i != price_steps - 1 {
+                matrix_row.push(super_diagonal(i as f64));
+            }
+
+            tridiagonal_matrix.push(matrix_row.clone());
+            matrix_row.clear()
+        }
+
+        tridiagonal_matrix
+    }
+
     fn invert_tridiagonal_matrix(&self, tridiagonal_matrix: Vec<Vec<f64>>) -> Vec<Vec<f64>> {
         
         let last = tridiagonal_matrix.len() - 1;

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -40,7 +40,8 @@ impl FiniteDifferencePricer {
         strike_price: f64, 
         risk_free_rate: f64, 
         volatility: f64, 
-        time_to_maturity: u16, 
+        evaluation_date: Option<Date>,
+        expiration_date: Date,
         type_flag: TypeFlag,
         exercise_flag: ExerciseFlag
     ) -> Self {
@@ -62,10 +63,6 @@ impl FiniteDifferencePricer {
         if volatility <= 0.0 {
             variables_with_error.push("volatility")
         } 
-
-        if time_to_maturity <= 0 {
-            variables_with_error.push("time_to_maturity")
-        }
 
         if variables_with_error.len() > 0 {
             if variables_with_error.len() == 1 {
@@ -92,7 +89,8 @@ impl FiniteDifferencePricer {
             strike_price, 
             risk_free_rate, 
             volatility, 
-            time_to_maturity, 
+            evaluation_date, 
+            expiration_date, 
             type_flag,
             exercise_flag
         }

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -313,7 +313,7 @@ impl FiniteDifferencePricer {
         let time_steps: u32 = self.time_steps();
         let delta_t: f64 = self.delta_t(time_steps);
     
-        let tridiagonal_matrix = self.create_tridiagonal_matrix(
+        let tridiagonal_matrix = self.create_tridiagonal_matrix_without_zeros(
             self.sub_diagonal(delta_t / 2.0), 
             self.diagonal(- delta_t), 
             self.super_diagonal(delta_t / 2.0), 
@@ -397,7 +397,7 @@ impl FiniteDifferencePricer {
             )
         );
         
-        let tridiagonal_future_matrix = self.create_tridiagonal_matrix(
+        let tridiagonal_future_matrix = self.create_tridiagonal_matrix_without_zeros(
             self.sub_diagonal(delta_t / 4.0), 
             self.diagonal(- delta_t / 2.0), 
             self.super_diagonal(delta_t / 4.0),

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -290,7 +290,7 @@ impl FiniteDifferencePricer {
         let time_steps: u32 = self.time_steps();
         let delta_t: f64 = self.delta_t(time_steps);
     
-        let tridiagonal_matrix = self.create_trimmed_tridiagonal_matrix(
+        let tridiagonal_matrix = self.create_tridiagonal_matrix(
             self.sub_diagonal(delta_t / 2.0), 
             self.diagonal(- delta_t), 
             self.super_diagonal(delta_t / 2.0), 
@@ -300,7 +300,7 @@ impl FiniteDifferencePricer {
         let mut u: Vec<f64> = self.boundary_condition_at_time_n(price_steps);
 
         for t in (1..time_steps).rev() {
-            u = self.trimmed_tridiagonal_matrix_multiply_vector(&tridiagonal_matrix, u);
+            u = self.matrix_multiply_vector(&tridiagonal_matrix, u);
 
             match self.type_flag {
                 TypeFlag::Call => {
@@ -374,7 +374,7 @@ impl FiniteDifferencePricer {
             )
         );
         
-        let tridiagonal_future_matrix = self.create_trimmed_tridiagonal_matrix(
+        let tridiagonal_future_matrix = self.create_tridiagonal_matrix(
             self.sub_diagonal(delta_t / 4.0), 
             self.diagonal(- delta_t / 2.0), 
             self.super_diagonal(delta_t / 4.0),
@@ -384,7 +384,7 @@ impl FiniteDifferencePricer {
         let mut u: Vec<f64> = self.boundary_condition_at_time_n(price_steps);
 
         for t in (1..time_steps).rev() {
-            u = self.trimmed_tridiagonal_matrix_multiply_vector(&tridiagonal_future_matrix, u);
+            u = self.matrix_multiply_vector(&tridiagonal_future_matrix, u);
 
             match self.type_flag {
                 TypeFlag::Call => {

--- a/src/instruments/options/mod.rs
+++ b/src/instruments/options/mod.rs
@@ -51,3 +51,6 @@ pub mod option;
 
 /// Power option pricers.
 pub mod power;
+
+/// Finite Difference Pricer
+pub mod finite_difference_pricer;


### PR DESCRIPTION
## Important Notes

This Pull Request is regarding issue https://github.com/avhz/RustQuant/issues/98 for the creation of a finite difference pricer. 

**I have made 2 PRs for this particular issue.** **_Only one of them needs to be merged if the decision has been made to merge._**

## [nalgebra](https://github.com/avhz/RustQuant/pull/212) vs heap allocated vectors

This PR uses heap allocated vectors to represent vectors and matrices with functions to handle the appropriate linear algebra calculations (+ matrix multiplication has been optimised for tridiagonal matrices). [The other PR utilises the nalgebra package.](https://github.com/avhz/RustQuant/pull/212)

**_The way in which the objects and methods should be used are exactly the same for both PRs._**

There are differences in speed performance between the two implementations.

An example with the following parameters:

```
initial_price: 3.22,
strike_price: 12.87,
risk_free_rate: 0.02,
volatility: 0.2,
evaluation_date: None,
expiration_date: today() + Duration::days(365),
time_steps: 1000,
price_steps: 100,
type_flag: TypeFlag::Put,
exercise_flag: ExerciseFlag::American
```

We get the following runtimes when we run one instance of both implementations

| Method      | vec (latest commit) | [nalgebra branch](https://github.com/avhz/RustQuant/pull/212)|
|--------------|--------------|------------|
| Explicit 		| 14.912845ms | 447.828518ms | 
| Implicit      | 212.050909ms |  548.617466ms | 
| Crank-Nicolson | 242.015886ms | 1.034193406s |

We can immediately see that the explicit method is about ~17 22~ 24  times faster using vectors (this PR) than using the [nalgebra package](https://github.com/avhz/RustQuant/pull/212) ~and runtime for the Crank-Nicolson method is roughly halved~ and runtime for the Crank-Nicolson method is 4 times faster and implicit method is roughly halved  (This is at least the case for the machine I am running the code on).

## Contents of this PR

This PR implements the following features:
- A struct, `FiniteDifferencePricer` in the module `instruments::options::finite_difference_pricer`, where the attributes are the parameters of an option, namely:
	- `initial_price: f64`
    - `strike_price: f64`
    - `risk_free_rate: f64`
    - `volatility: f64`
    -  `evaluation_date: Option<Date>`,
    -  `expiration_date: Date`,
    - `time_steps: u32`,
    - `price_steps: u32`,
    - `type_flag: TypeFlag`,
    - `exercise_flag: ExerciseFlag`

    where `TypeFlag` and `ExerciseFlag` are imported from `instruments::options::option`
- A constructor for the above `struct` with the `new()` method which takes in the above defined attributes as arguments
- Three public methods implemented in the `FiniteDifferencePricer` for the three widely known finite difference methods, namely `explicit()`, `implicit()` and `crank_nicolson()` which returns the option price rounded to 2 decimal places

## Demonstration by example

We can start off by defining the finite difference object by calling the `new()` constructor 

```
use RustQuant::instruments::options::{
    option::{TypeFlag, ExerciseFlag},
    finite_difference_pricer::FiniteDifferencePricer,
};

let finite_difference_obj = FiniteDifferencePricer::new(
    15.55,                            // initial_price
    10.2,                             // strike_price
    0.1,                              // risk_free_rate
    0.025,                            // volatility
    None,                             // evaluation_date
    today() + Duration::days(1),      // expiration_date
    1000,                             // time_steps
    100,                              // price_steps
    TypeFlag::Call,                   // type_flag
    ExerciseFlag::American            // exercise_flag
);
```

Now that the object has been defined, we can run any of the 3 methods to provide a numerical approximation of the option price:

```
println!("Explicit method: {}", finite_difference_obj.explicit());
println!("Implicit method: {}", finite_difference_obj.implicit());
println!("Crank-Nicolson: {}", finite_difference_obj.crank_nicolson());
```

Running the above code yields the following results:

```
Explicit method: 5.35
Implicit method: 5.35
Crank-Nicolson: 5.35
```

### Notes
1. Since I am using heap allocated vectors in this PR, I have had to manually calculate the inverse for the tridiagonal matrix for the implicit and Crank-Nicolson finite difference methods. I have done so by implementing the theorem outlined in [this paper](https://www.sciencedirect.com/science/article/pii/0024379594904146?ref=pdf_download&fr=RR-2&rr=872419691b857702).

2. I have opted to solve this problem using a `struct` to define the option parameters and from there we can run each finite difference method from the object. Alternatively, I could amend the PR so that it can be purely functional.

3. The code utilises the Dirichlet condition for the boundaries of the stock price extremities.

If we define the following:

$$V^{m}_{n} - \text{The option price at time step } n \text{ and price step } m\text{ (with maximum } M\text{)}$$

$$T - \text{Maturity time}$$

$$K - \text{Strike price}$$

$$S_{M} - \text{Maximum price of the underlying asset}$$
 
$$\Delta t - \text{Time step size}$$

Then Dirichlet boundary conditions for the call options are:

$$V^{0}_{n} = 0$$

$$V^{M}_{n} = S_M - Ke^{-r(T-n\Delta t)}$$

and for the put options:

$$V^{0}_{n} =Ke^{-r(T-n\Delta t)}$$

$$V^{M}_{n} = 0$$

4. We can also implement the option use the Neumann conditions, perhaps in another pull request in the future. 

## ~EDIT 1: Optimisation amendments~

~In the code there are two private methods that seemingly do the same thing, `create_tridiagonal_matrix()` and `create_trimmed_tridiagonal_matrix()`. The difference between the two is that the former returns the matrx representation whole i.e. inclusive of all outer zeros, whilst the former only stores the the values of the three diagonals on a row by row basis.~

~As such, two private methods for matrix multiplication had to be created to handle the two data structures, appropriately named `matrix_multiply_vector()` and `trimmed_tridiagonal_matrix_multiply_vector()`.~

~The reason both representation exist is because for explicit methods, only the diagonal values of the matrix are required to implement the approximation, whereas for implicit methods we require the whole matrix in order to calculate its inverse (though, this can be amended in a future PR).~

~This change has fractionally increased speed performances for `explicit()` and `crank_nicolson()`.~

<h2 id="edit_2">EDIT 2: Condensing methods + single data structure for tridiagonal matrices</h2>

Previously two distinct representations of a tridiagonal matrix were implemented:
 - Data structure 1: A vector containing vectors representing rows in the matrix
 - Data structure 2: A vector containing vectors of only the tridiagonal elements in a row

An example for each case respectively:

Data structure 1:
```
[
  [2,1,0,0,0],
  [1,2,1,0,0],
  [0,1,2,1,0],
  [0,0,1,2,1],
  [0,0,0,1,2],
]
```

Data structure 2:
```
[
  [2,1],
  [1,2,1],
  [1,2,1],
  [1,2,1],
  [1,2],
]
```
This branch will now only utilise data structure 2 to represent tridiagonal matrices and operations.