### PR TITLE
Finite difference pricer adjustments

### DIFF
--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -111,29 +111,25 @@ impl FiniteDifferencePricer {
         Av
     }
 
-    fn create_tridiagonal_matrix<A, B, C>(
+    fn create_tridiagonal_matrix(
         &self,
-        sub_diagonal: A,
-        diagonal: B,
-        super_diagonal: C,
+        sub_diagonal: f64,
+        diagonal: f64,
+        super_diagonal: f64
     ) -> Vec<Vec<f64>>
-    where
-        A: Fn(f64) -> f64,
-        B: Fn(f64) -> f64,
-        C: Fn(f64) -> f64,
     {
         let mut matrix_row: Vec<f64> = Vec::new();
         let mut tridiagonal_matrix: Vec<Vec<f64>> = Vec::new();
 
         for i in 1..(self.price_steps) {
             if i != 1 {
-                matrix_row.push(sub_diagonal(i as f64));
+                matrix_row.push(sub_diagonal);
             }
 
-            matrix_row.push(diagonal(i as f64));
+            matrix_row.push(diagonal);
 
             if i != self.price_steps - 1 {
-                matrix_row.push(super_diagonal(i as f64));
+                matrix_row.push(super_diagonal);
             }
 
             tridiagonal_matrix.push(matrix_row.clone());

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -103,7 +103,7 @@ impl FiniteDifferencePricer {
         Av
     }
 
-    fn matrix_multiply_vector(&self, A: &[Vec<f64>], v: Vec<f64>) -> Vec<f64> {
+    fn general_matrix_multiply_vector(&self, A: &[Vec<f64>], v: Vec<f64>) -> Vec<f64> {
         let mut Av: Vec<f64> = Vec::new();
         let mut value: f64;
 
@@ -313,7 +313,7 @@ impl FiniteDifferencePricer {
                 }
             }
 
-            v = self.matrix_multiply_vector(&inverse_matrix, v);
+            v = self.general_matrix_multiply_vector(&inverse_matrix, v);
 
             if let ExerciseFlag::American = self.exercise_flag {
                 v = self.american_time_stop_step(v, (t as f64) * delta_t, x_min, delta_x);
@@ -360,7 +360,7 @@ impl FiniteDifferencePricer {
                 }
             }
 
-            v = self.matrix_multiply_vector(&inverse_future_matrix, v);
+            v = self.general_matrix_multiply_vector(&inverse_future_matrix, v);
 
             if let ExerciseFlag::American = self.exercise_flag {
                 v = self.american_time_stop_step(v, (t as f64) * delta_t, x_min, delta_x);

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -125,14 +125,14 @@ impl FiniteDifferencePricer {
         let mut matrix_row: Vec<f64> = Vec::new();
         let mut tridiagonal_matrix: Vec<Vec<f64>> = Vec::new();
 
-        for i in 1..(price_steps) {
+        for i in 1..(self.price_steps) {
             if i != 1 {
                 matrix_row.push(sub_diagonal(i as f64));
             }
 
             matrix_row.push(diagonal(i as f64));
 
-            if i != price_steps - 1 {
+            if i != self.price_steps - 1 {
                 matrix_row.push(super_diagonal(i as f64));
             }
 

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -331,25 +331,24 @@ impl FiniteDifferencePricer {
     pub fn implicit(&self) -> f64 {
         let (T, delta_t) = self.time_structure();
 
-        let inverse_matrix = self.invert_tridiagonal_matrix(self.create_tridiagonal_matrix(
-            self.sub_diagonal(-delta_t / 2.0),
-            self.diagonal(delta_t),
-            self.super_diagonal(-delta_t / 2.0),
-            self.price_steps,
+        let inverse_matrix: Vec<Vec<f64>> = self.invert_tridiagonal_matrix(self.create_tridiagonal_matrix(
+                self.sub_diagonal(- delta_t / 2.0),
+                self.diagonal(delta_t),
+                self.super_diagonal(- delta_t / 2.0)
         ));
 
-        let mut u: Vec<f64> = self.boundary_condition_at_time_n(self.price_steps);
+        let mut u: Vec<f64> = self.boundary_condition_at_time_n();
 
-        for t in (1..self.time_steps).rev() {
+        for t in (0..self.time_steps).rev() {
             match self.type_flag {
                 TypeFlag::Call => {
                     u[(self.price_steps - 2) as usize] -=
-                        self.super_diagonal(-delta_t / 2.0)((self.price_steps - 1) as f64)
-                            * self.call_boundary(t, T, delta_t);
+                        self.super_diagonal(- delta_t / 2.0)((self.price_steps - 1) as f64)
+                            * self.call_boundary(t + 1, T, delta_t);
                 }
                 TypeFlag::Put => {
-                    u[0] +=
-                        self.sub_diagonal(delta_t / 2.0)(1.0) * self.put_boundary(t, T, delta_t);
+                    u[0] -=
+                        self.sub_diagonal(delta_t / 2.0)(1.0) * self.put_boundary(t + 1, T, delta_t);
                 }
             }
 

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -256,11 +256,6 @@ impl FiniteDifferencePricer {
         )
     }
 
-    fn time_structure(&self) -> (f64, f64) {
-        let T: f64 = self.year_fraction();
-        (T, T / (self.time_steps as f64))
-    }
-
     fn return_price(&self, u: Vec<f64>) -> f64 {
         match self.price_steps % 2 {
             0 => u[((self.price_steps - 1) / 2) as usize],

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -296,16 +296,15 @@ impl FiniteDifferencePricer {
     pub fn explicit(&self) -> f64 {
         let (T, delta_t) = self.time_structure();
 
-        let tridiagonal_matrix = self.create_tridiagonal_matrix(
+        let tridiagonal_matrix: Vec<Vec<f64>> = self.create_tridiagonal_matrix(
             self.sub_diagonal(delta_t / 2.0),
             self.diagonal(-delta_t),
-            self.super_diagonal(delta_t / 2.0),
-            self.price_steps,
+            self.super_diagonal(delta_t / 2.0)
         );
 
-        let mut u: Vec<f64> = self.boundary_condition_at_time_n(self.price_steps);
+        let mut u: Vec<f64> = self.boundary_condition_at_time_n();
 
-        for t in (1..self.time_steps).rev() {
+        for t in (0..self.time_steps).rev() {
             u = self.matrix_multiply_vector(&tridiagonal_matrix, u);
 
             match self.type_flag {

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -92,16 +92,14 @@ impl FiniteDifferencePricer {
     ) -> Vec<f64> {
         let mut Av: Vec<f64> = Vec::new();
 
-        for i in 0..v.len() {
-            Av.push(
-                match i 
-                    {
-                        k if k == 0 => diagonal * v[0] + super_diagonal * v[1],
-                        k if k == v.len() - 1 => sub_diagonal * v[v.len() - 2] + diagonal * v[v.len() - 1],
-                        _ => sub_diagonal * v[i - 1] + diagonal * v[i] + super_diagonal * v[i + 1]
-                    }
-            )
+        Av.push(diagonal * v[0] + super_diagonal * v[1]);
+
+        for i in 1..(v.len() - 1) {
+            Av.push(sub_diagonal * v[i - 1] + diagonal * v[i] + super_diagonal * v[i + 1])
         }
+        
+        Av.push(sub_diagonal * v[v.len() - 2] + diagonal * v[v.len() - 1]);
+
         Av
     }
 

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -397,18 +397,18 @@ impl FiniteDifferencePricer {
 mod tests_finite_difference_pricer_at_the_money {
     use super::*;
     use crate::assert_approx_equal;
-    use crate::RUSTQUANT_EPSILON as EPS;
     use time::macros::date;
 
+    const EPS: f64 = 1e-4;
     const EUROPEAN_CALL: FiniteDifferencePricer = FiniteDifferencePricer {
         initial_price: 10.0,
         strike_price: 10.0,
         risk_free_rate: 0.05,
-        volatility: 0.5,
+        volatility: 0.1,
         evaluation_date: Some(date!(2024 - 01 - 01)),
         expiration_date: date!(2025 - 01 - 01),
-        time_steps: 1000,
-        price_steps: 100,
+        time_steps: 10000,
+        price_steps: 250,
         type_flag: TypeFlag::Call,
         exercise_flag: ExerciseFlag::European,
     };
@@ -417,11 +417,11 @@ mod tests_finite_difference_pricer_at_the_money {
         initial_price: 10.0,
         strike_price: 10.0,
         risk_free_rate: 0.05,
-        volatility: 0.5,
+        volatility: 0.1,
         evaluation_date: Some(date!(2024 - 01 - 01)),
         expiration_date: date!(2025 - 01 - 01),
-        time_steps: 1000,
-        price_steps: 100,
+        time_steps: 10000,
+        price_steps: 250,
         type_flag: TypeFlag::Put,
         exercise_flag: ExerciseFlag::European,
     };
@@ -430,11 +430,11 @@ mod tests_finite_difference_pricer_at_the_money {
         initial_price: 10.0,
         strike_price: 10.0,
         risk_free_rate: 0.05,
-        volatility: 0.5,
+        volatility: 0.1,
         evaluation_date: Some(date!(2024 - 01 - 01)),
         expiration_date: date!(2025 - 01 - 01),
-        time_steps: 1000,
-        price_steps: 100,
+        time_steps: 10000,
+        price_steps: 250,
         type_flag: TypeFlag::Call,
         exercise_flag: ExerciseFlag::American,
     };
@@ -443,19 +443,19 @@ mod tests_finite_difference_pricer_at_the_money {
         initial_price: 10.0,
         strike_price: 10.0,
         risk_free_rate: 0.05,
-        volatility: 0.5,
+        volatility: 0.1,
         evaluation_date: Some(date!(2024 - 01 - 01)),
         expiration_date: date!(2025 - 01 - 01),
-        time_steps: 1000,
-        price_steps: 100,
+        time_steps: 10000,
+        price_steps: 250,
         type_flag: TypeFlag::Put,
         exercise_flag: ExerciseFlag::American,
     };
 
-    const EXPECT_A_CALL: f64 = 2.179_260_421_286_684_845;
-    const EXPECT_A_PUT: f64 = 1.746_847_694_033_270_004;
-    const EXPECT_E_CALL: f64 = 2.179_260_421_286_684_845;
-    const EXPECT_E_PUT: f64 = 1.691_554_666_293_823_894;
+    const EXPECT_A_CALL: f64 = 0.680_478_009_892_241;
+    const EXPECT_A_PUT: f64 = 0.243_630_311_556;
+    const EXPECT_E_CALL: f64 = 0.680_495_770_882_215;
+    const EXPECT_E_PUT: f64 = 0.192_790_015_889_355;
 
     #[test]
     fn american_call_explicit() {
@@ -526,18 +526,18 @@ mod tests_finite_difference_pricer_at_the_money {
 mod tests_finite_difference_pricer_in_the_money {
     use super::*;
     use crate::assert_approx_equal;
-    use crate::RUSTQUANT_EPSILON as EPS;
     use time::macros::date;
 
+    const EPS: f64 = 1e-5;
     const EUROPEAN_CALL: FiniteDifferencePricer = FiniteDifferencePricer {
         initial_price: 15.0,
         strike_price: 10.0,
         risk_free_rate: 0.05,
-        volatility: 0.5,
+        volatility: 0.1,
         evaluation_date: Some(date!(2024 - 01 - 01)),
         expiration_date: date!(2025 - 01 - 01),
-        time_steps: 1000,
-        price_steps: 100,
+        time_steps: 10000,
+        price_steps: 200,
         type_flag: TypeFlag::Call,
         exercise_flag: ExerciseFlag::European,
     };
@@ -546,11 +546,11 @@ mod tests_finite_difference_pricer_in_the_money {
         initial_price: 10.0,
         strike_price: 15.0,
         risk_free_rate: 0.05,
-        volatility: 0.5,
+        volatility: 0.1,
         evaluation_date: Some(date!(2024 - 01 - 01)),
         expiration_date: date!(2025 - 01 - 01),
-        time_steps: 1000,
-        price_steps: 100,
+        time_steps: 10000,
+        price_steps: 200,
         type_flag: TypeFlag::Put,
         exercise_flag: ExerciseFlag::European,
     };
@@ -559,11 +559,11 @@ mod tests_finite_difference_pricer_in_the_money {
         initial_price: 15.0,
         strike_price: 10.0,
         risk_free_rate: 0.05,
-        volatility: 0.5,
+        volatility: 0.1,
         evaluation_date: Some(date!(2024 - 01 - 01)),
         expiration_date: date!(2025 - 01 - 01),
-        time_steps: 1000,
-        price_steps: 100,
+        time_steps: 10000,
+        price_steps: 200,
         type_flag: TypeFlag::Call,
         exercise_flag: ExerciseFlag::American,
     };
@@ -572,19 +572,19 @@ mod tests_finite_difference_pricer_in_the_money {
         initial_price: 10.0,
         strike_price: 15.0,
         risk_free_rate: 0.05,
-        volatility: 0.5,
+        volatility: 0.1,
         evaluation_date: Some(date!(2024 - 01 - 01)),
         expiration_date: date!(2025 - 01 - 01),
-        time_steps: 1000,
-        price_steps: 100,
+        time_steps: 10000,
+        price_steps: 200,
         type_flag: TypeFlag::Put,
         exercise_flag: ExerciseFlag::American,
     };
 
-    const EXPECT_A_CALL: f64 = 6.0644265045002292425;
-    const EXPECT_A_PUT: f64 = 5.3274412554240626605;
-    const EXPECT_E_CALL: f64 = 6.0644265045002292425;
-    const EXPECT_E_PUT: f64 = 5.0913969604477404829;
+    const EXPECT_A_CALL: f64 = 5.487_706_388_002_172;
+    const EXPECT_A_PUT: f64 = 4.999_999_999_999_999;
+    const EXPECT_E_CALL: f64 = 5.487_706_388_002_172;
+    const EXPECT_E_PUT: f64 = 4.268_497_436_100_947;
 
     #[test]
     fn american_call_explicit() {
@@ -655,65 +655,65 @@ mod tests_finite_difference_pricer_in_the_money {
 mod tests_finite_difference_pricer_out_of_the_money {
     use super::*;
     use crate::assert_approx_equal;
-    use crate::RUSTQUANT_EPSILON as EPS;
     use time::macros::date;
 
+    const EPS: f64 = 1e-5;
     const EUROPEAN_CALL: FiniteDifferencePricer = FiniteDifferencePricer {
-        initial_price: 1.0,
-        strike_price: 10.0,
+        initial_price: 10.0,
+        strike_price: 15.0,
         risk_free_rate: 0.05,
-        volatility: 0.5,
+        volatility: 0.1,
         evaluation_date: Some(date!(2024 - 01 - 01)),
         expiration_date: date!(2025 - 01 - 01),
-        time_steps: 1000,
-        price_steps: 100,
+        time_steps: 10000,
+        price_steps: 200,
         type_flag: TypeFlag::Call,
         exercise_flag: ExerciseFlag::European,
     };
 
     const EUROPEAN_PUT: FiniteDifferencePricer = FiniteDifferencePricer {
-        initial_price: 10.0,
-        strike_price: 1.0,
+        initial_price: 15.0,
+        strike_price: 10.0,
         risk_free_rate: 0.05,
-        volatility: 0.5,
+        volatility: 0.1,
         evaluation_date: Some(date!(2024 - 01 - 01)),
         expiration_date: date!(2025 - 01 - 01),
-        time_steps: 1000,
-        price_steps: 100,
+        time_steps: 10000,
+        price_steps: 200,
         type_flag: TypeFlag::Put,
         exercise_flag: ExerciseFlag::European,
     };
 
     const AMERICAN_CALL: FiniteDifferencePricer = FiniteDifferencePricer {
-        initial_price: 1.0,
-        strike_price: 10.0,
+        initial_price: 10.0,
+        strike_price: 15.0,
         risk_free_rate: 0.05,
-        volatility: 0.5,
+        volatility: 0.1,
         evaluation_date: Some(date!(2024 - 01 - 01)),
         expiration_date: date!(2025 - 01 - 01),
-        time_steps: 1000,
-        price_steps: 100,
+        time_steps: 10000,
+        price_steps: 200,
         type_flag: TypeFlag::Call,
         exercise_flag: ExerciseFlag::American,
     };
 
     const AMERICAN_PUT: FiniteDifferencePricer = FiniteDifferencePricer {
-        initial_price: 10.0,
-        strike_price: 1.0,
+        initial_price: 15.0,
+        strike_price: 10.0,
         risk_free_rate: 0.05,
-        volatility: 0.5,
+        volatility: 0.1,
         evaluation_date: Some(date!(2024 - 01 - 01)),
         expiration_date: date!(2025 - 01 - 01),
-        time_steps: 1000,
-        price_steps: 100,
+        time_steps: 10000,
+        price_steps: 200,
         type_flag: TypeFlag::Put,
         exercise_flag: ExerciseFlag::American,
     };
 
-    const EXPECT_A_CALL: f64 = 0.0000010140475396182350785;
-    const EXPECT_A_PUT: f64 = 0.000014933019126383249514;
-    const EXPECT_E_CALL: f64 = 0.0000010140475396182350785;
-    const EXPECT_E_PUT: f64 = 0.00000037356944149356531733;
+    const EXPECT_A_CALL: f64 = 0.000_059_393_327_777_911;
+    const EXPECT_A_PUT: f64 = 0.000_000_693_279_415_654_018;
+    const EXPECT_E_CALL: f64 = 0.000_056_068_590_237_768;
+    const EXPECT_E_PUT: f64 = 0.000_000_633_009_309_923_640;
 
     #[test]
     fn american_call_explicit() {

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -116,7 +116,6 @@ impl FiniteDifferencePricer {
         sub_diagonal: A,
         diagonal: B,
         super_diagonal: C,
-        price_steps: u32,
     ) -> Vec<Vec<f64>>
     where
         A: Fn(f64) -> f64,

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -254,19 +254,19 @@ impl FiniteDifferencePricer {
             .collect()
     }
 
-    fn boundary_condition_at_time_n(&self, price_steps: u32) -> Vec<f64> {
-        (1..(price_steps))
-            .map(|i| self.payoff(((i) as f64) * (2.0 * self.initial_price / (price_steps as f64))))
+    fn boundary_condition_at_time_n(&self) -> Vec<f64> {
+        (1..(self.price_steps))
+            .map(|i: u32| self.payoff((i as f64) * (2.0 * self.initial_price / (self.price_steps as f64))))
             .collect()
     }
 
     fn call_boundary(&self, t: u32, T: f64, delta_t: f64) -> f64 {
         2.0 * self.initial_price
-            - self.strike_price * f64::exp(-(self.risk_free_rate * T) - (t as f64 * delta_t))
+            - self.strike_price * f64::exp(-self.risk_free_rate * (T - (t as f64 * delta_t)))
     }
 
     fn put_boundary(&self, t: u32, T: f64, delta_t: f64) -> f64 {
-        self.strike_price * f64::exp(-(self.risk_free_rate * T) - (t as f64 * delta_t))
+        self.strike_price * f64::exp(-(self.risk_free_rate * (T - t as f64 * delta_t)))
     }
 
     fn year_fraction(&self) -> f64 {

--- a/src/instruments/options/finite_difference_pricer.rs
+++ b/src/instruments/options/finite_difference_pricer.rs
@@ -367,22 +367,20 @@ impl FiniteDifferencePricer {
         let (T, delta_t) = self.time_structure();
 
         let inverse_past_matrix = self.invert_tridiagonal_matrix(self.create_tridiagonal_matrix(
-            self.sub_diagonal(-delta_t / 4.0),
+            self.sub_diagonal(- delta_t / 4.0),
             self.diagonal(delta_t / 2.0),
-            self.super_diagonal(-delta_t / 4.0),
-            self.price_steps,
+            self.super_diagonal(- delta_t / 4.0)
         ));
 
-        let tridiagonal_future_matrix = self.create_tridiagonal_matrix(
+        let tridiagonal_future_matrix: Vec<Vec<f64>> = self.create_tridiagonal_matrix(
             self.sub_diagonal(delta_t / 4.0),
-            self.diagonal(-delta_t / 2.0),
-            self.super_diagonal(delta_t / 4.0),
-            self.price_steps,
+            self.diagonal(- delta_t / 2.0),
+            self.super_diagonal(delta_t / 4.0)
         );
 
-        let mut u: Vec<f64> = self.boundary_condition_at_time_n(self.price_steps);
+        let mut u: Vec<f64> = self.boundary_condition_at_time_n();
 
-        for t in (1..self.time_steps).rev() {
+        for t in (0..self.time_steps).rev() {
             u = self.matrix_multiply_vector(&tridiagonal_future_matrix, u);
 
             match self.type_flag {
@@ -390,11 +388,11 @@ impl FiniteDifferencePricer {
                     u[(self.price_steps - 2) as usize] +=
                         self.super_diagonal(delta_t / 4.0)((self.price_steps - 1) as f64)
                             * (self.call_boundary(t + 1, T, delta_t)
-                                - self.call_boundary(t, T, delta_t))
+                                + self.call_boundary(t, T, delta_t))
                 }
                 TypeFlag::Put => {
                     u[0] += self.sub_diagonal(delta_t / 4.0)(1.0)
-                        * (self.put_boundary(t + 1, T, delta_t) - self.put_boundary(t, T, delta_t))
+                        * (self.put_boundary(t + 1, T, delta_t) + self.put_boundary(t, T, delta_t))
                 }
             }
 


### PR DESCRIPTION
## *This branch is still a work in progress*

This PR is for addressing the issues raised by @avhz in [this comment](https://github.com/avhz/RustQuant/issues/98#issuecomment-2078053371) - the code in question was initially merged from [this PR](https://github.com/avhz/RustQuant/pull/211) to address  [issue 98](https://github.com/avhz/RustQuant/issues/98).

There were some errors in implementation, namely:

- Call/Put boundary conditions had implemented $e^{-rT - t}$ instead of $e^{-r(T - t)}$
- The time steps were iterating `(1..self.time_steps)` instead of `(0..self.time_steps)`
- The boundary condition for the Crank-Nicolson method was implemented as `self.call_boundary(t + 1, T, delta_t)
                                - self.call_boundary(t, T, delta_t)` when it should be `self.call_boundary(t + 1, T, delta_t)
                                + self.call_boundary(t, T, delta_t)` (same amendment made for put option boundary

Although the above amendments have been made, there are still issues with convergence in some places. For brevity, I have limited the cases to European call options.

The cases below were run with the following configuration:

```
strike_price:  10.0;
risk_free_rate:  0.05;
volatility: 0.5;
evaluation_date: Some(date!(2024 - 01 - 01));
expiration_date: date!(2025 - 01 - 01);
time_steps: 10000; // increased 10-fold for stability - see note below
price_steps: 100;
type_flag: TypeFlag::Call;
exercise_flag: ExerciseFlag::European;
```
with a distinct value for `initial_price` in each case: 

## At the money

`initial_price: 10.0`
Target: 2.179260421286683
| Method      | Value      | Error  |
| ------------- | ------------- | ------------- |
| Explicit | 2.1752124177257035 |  0.004048003560979563 |
| Implicit | 2.1751386801265697 |  0.004121741160113324 |
| Crank-Nicolson | 2.175175548933553 |  0.004084872353129931 |

## In the money

`initial_price: 15.0`
Target: 6.064426504411616

| Method      | Value      | Error  |
| ------------- | ------------- | ------------- |
| Explicit | 6.064451145206732 | 0.00002464079511632633 |
| Implicit | 6.06441080128941 |  0.00001570312220611214 |
| Crank-Nicolson | 6.064430972254538 |  0.000004467842922295517 |

## Out the money

`initial_price: 1.0`
Target: 1.0140475395001201e-6

| Method      | Value      | Error  |
| ------------- | ------------- | ------------- |
| Explicit | -1.0119200252625027 |  1.0119210393100422 |
| Implicit | -1.011847275245909 |  1.0118482892934484 |
| Crank-Nicolson | -1.011883645221771 |  1.0118846592693105 |

There is some level of convergence for the *at/in the money* cases, although I think there is room for improvement for accuracy. Whilst experimenting with different time step sizes, it seems that there is an issue with consistency i.e. $\Delta t \rightarrow 0 \Rightarrow \text{Error}\rightarrow 0$ - this suggests there is *still* an issue with implementation - Note that **_there is convergence_**, but just not to the target value. The *out the money* case further confirms that there is something wrong. 

## Stability issues
It was noticed that `explicit()` was *blowing up* in some configurations. It is likely that this indicates an issue with stability, which can be resolved by having a larger time steps, which in turn provides smaller $\Delta t$. Hence, in the config above, I changed the time step from 1000 to 10000 (though 5000 suffices for stability).