### PR TITLE
feat: Add Makefile for common project tasks and pre-push checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+
+# Makefile for common tasks in a Rust project
+
+# Default target
+.PHONY: all
+all: build
+
+# Build the project
+.PHONY: build
+build:
+	cargo build
+
+# Run tests
+.PHONY: test
+test:
+	cargo test
+
+# Format the code
+.PHONY: fmt
+fmt:
+	cargo +nightly fmt --all
+
+# Check formatting
+.PHONY: fmt-check
+fmt-check:
+	cargo +nightly fmt --check
+
+# Run Clippy for linting
+.PHONY: lint
+lint:
+	cargo clippy --all-targets --all-features -- -D warnings
+
+# Clean the project
+.PHONY: clean
+clean:
+	cargo clean
+
+# Pre-push checks
+.PHONY: pre-push
+pre-push: test fmt-check lint
+
+# Run the project
+.PHONY: run
+run:
+	cargo run


### PR DESCRIPTION
- Introduced a Makefile to streamline common tasks in the Rust project.
- Included targets for building, testing, formatting, linting, cleaning, and running the project.
- Added a `pre-push` target that runs critical checks before pushing code to the repository:
  - Executes `cargo test` to ensure all tests pass.
  - Runs `cargo +nightly fmt --all` to format the code and avoid formatting issues.
  - Uses `cargo clippy` to lint the code and enforce code quality standards.

This Makefile enhances the development workflow by providing a single interface for essential tasks, ensuring code quality and consistency before code is pushed to the repository.
