### PR TITLE
Fixed the exponential interpolator

### DIFF
--- a/src/math/interpolation/exponential_interpolator.rs
+++ b/src/math/interpolation/exponential_interpolator.rs
@@ -9,11 +9,9 @@
 
 //! Module containing functionality for interpolation.
 
-use rand_distr::num_traits;
-
-use crate::math::interpolation::{InterpolationError, InterpolationIndex, InterpolationValue};
-
 use super::Interpolator;
+use crate::math::interpolation::{InterpolationError, InterpolationIndex, InterpolationValue};
+use num::Float;
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // STRUCTS & ENUMS
@@ -22,7 +20,7 @@ use super::Interpolator;
 /// Exponential Interpolator.
 pub struct ExponentialInterpolator<IndexType, ValueType>
 where
-    IndexType: InterpolationIndex,
+    IndexType: InterpolationIndex<DeltaDiv = ValueType>,
     ValueType: InterpolationValue,
 {
     /// X-axis values for the interpolator.
@@ -41,7 +39,7 @@ where
 
 impl<IndexType, ValueType> ExponentialInterpolator<IndexType, ValueType>
 where
-    IndexType: InterpolationIndex,
+    IndexType: InterpolationIndex<DeltaDiv = ValueType>,
     ValueType: InterpolationValue,
 {
     /// Create a new ExponentialInterpolator.
@@ -77,7 +75,7 @@ impl<IndexType, ValueType> Interpolator<IndexType, ValueType>
     for ExponentialInterpolator<IndexType, ValueType>
 where
     IndexType: InterpolationIndex<DeltaDiv = ValueType>,
-    ValueType: InterpolationValue + num_traits::Float,
+    ValueType: InterpolationValue + Float,
 {
     fn fit(&mut self) -> Result<(), InterpolationError> {
         self.fitted = true;
@@ -132,7 +130,7 @@ where
 #[cfg(test)]
 mod tests_exponential_interpolation {
     use super::*;
-    use crate::{assert_approx_equal, math::interpolation, RUSTQUANT_EPSILON};
+    use crate::{assert_approx_equal, RUSTQUANT_EPSILON};
     use time::macros::date;
 
     #[test]

--- a/src/math/interpolation/linear_interpolator.rs
+++ b/src/math/interpolation/linear_interpolator.rs
@@ -20,7 +20,7 @@ use crate::math::interpolation::{
 /// Linear Interpolator.
 pub struct LinearInterpolator<IndexType, ValueType>
 where
-    IndexType: InterpolationIndex,
+    IndexType: InterpolationIndex<DeltaDiv = ValueType>,
     ValueType: InterpolationValue,
 {
     /// X-axis values for the interpolator.

--- a/src/math/interpolation/linear_interpolator.rs
+++ b/src/math/interpolation/linear_interpolator.rs
@@ -39,7 +39,7 @@ where
 
 impl<IndexType, ValueType> LinearInterpolator<IndexType, ValueType>
 where
-    IndexType: InterpolationIndex,
+    IndexType: InterpolationIndex<DeltaDiv = ValueType>,
     ValueType: InterpolationValue,
 {
     /// Create a new LinearInterpolator.


### PR DESCRIPTION
Fixed the exponential interpolator.

https://github.com/avhz/RustQuant/pull/162#issuecomment-1926279538

One of the changes was in the actual computation to the exponential interpolation. I'm not too sure how your method previously worked, but the following method is quite straightforward, and it seems to fix the issue.

Method:
0. Starting with `(x_1, y_1)` and `(x_2, y_2)` and we want to interpolate at some point `x_1 < p < x_2`.
1. Take the `log` of the y-values. That is, we now have `(x_1, ln(y_1))` and `(x_2, ln(y_2))`.
2. Use linear interpolation between these two points.
3. Apply `exp` to it to convert back out of logspace.
