### PR TITLE
Monte-Carlo Engine, seed parameter implementation and new numerical schemes for SDEs

### DIFF
--- a/crates/RustQuant_instruments/src/monte_carlo_pricer.rs
+++ b/crates/RustQuant_instruments/src/monte_carlo_pricer.rs
@@ -41,7 +41,7 @@ macro_rules! impl_monte_carlo_pricer {
                 config: &StochasticProcessConfig,
                 rate: f64,
             ) -> f64 {
-                let out = process.euler_maruyama(&config);
+                let out = process.monte_carlo(&config);
 
                 let n = out.paths.len();
 

--- a/crates/RustQuant_instruments/src/monte_carlo_pricer.rs
+++ b/crates/RustQuant_instruments/src/monte_carlo_pricer.rs
@@ -41,7 +41,7 @@ macro_rules! impl_monte_carlo_pricer {
                 config: &StochasticProcessConfig,
                 rate: f64,
             ) -> f64 {
-                let out = process.monte_carlo(&config);
+                let out = process.generate(&config);
 
                 let n = out.paths.len();
 

--- a/crates/RustQuant_instruments/src/options/vanilla.rs
+++ b/crates/RustQuant_instruments/src/options/vanilla.rs
@@ -389,7 +389,7 @@ mod test_vanilla_option_monte_carlo {
     use std::time::Instant;
     use time::macros::date;
     use RustQuant_stochastics::geometric_brownian_motion::GeometricBrownianMotion;
-    use RustQuant_stochastics::StochasticProcessConfig;
+    use RustQuant_stochastics::{StochasticProcessConfig, StochasticScheme};
 
     #[test]
     fn test_vanilla_option_monte_carlo() {
@@ -410,7 +410,9 @@ mod test_vanilla_option_monte_carlo {
         let process = GeometricBrownianMotion::new(interest_rate, volatility);
 
         let config =
-            StochasticProcessConfig::new(underlying, 0.0, time_to_maturity, 1, 1_000_000, true);
+            StochasticProcessConfig::new(
+                underlying, 0.0, time_to_maturity, 1, StochasticScheme::EulerMaruyama,1_000_000, true, None
+            );
 
         let start = Instant::now();
         let price = option.price_monte_carlo(&process, &config, interest_rate);
@@ -442,7 +444,9 @@ mod test_vanilla_option_monte_carlo {
         let process = GeometricBrownianMotion::new(interest_rate, volatility);
 
         let config =
-            StochasticProcessConfig::new(underlying, 0.0, time_to_maturity, 1000, 1000, true);
+            StochasticProcessConfig::new(
+                underlying, 0.0, time_to_maturity, 1000, StochasticScheme::EulerMaruyama,1000, true, None
+            );
 
         let start = Instant::now();
         let price = option.price_monte_carlo(&process, &config, interest_rate);

--- a/crates/RustQuant_stochastics/src/arithmetic_brownian_motion.rs
+++ b/crates/RustQuant_stochastics/src/arithmetic_brownian_motion.rs
@@ -67,7 +67,7 @@ mod tests_abm {
         let config = StochasticProcessConfig::new(
             10.0, 0.0, 0.5, 125, StochasticScheme::EulerMaruyama, 1000, false, None
         );
-        let output = abm.monte_carlo(&config);
+        let output = abm.generate(&config);
 
         // let file1 = "./images/ABM1.png";
         // plot_vector((&output.trajectories[0]).clone(), file1).unwrap();

--- a/crates/RustQuant_stochastics/src/arithmetic_brownian_motion.rs
+++ b/crates/RustQuant_stochastics/src/arithmetic_brownian_motion.rs
@@ -7,7 +7,6 @@
 //      - LICENSE-MIT.md
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-// use crate::models::arithmetic_brownian_motion::ArithmeticBrownianMotion;
 use crate::process::StochasticProcess;
 use crate::ModelParameter;
 

--- a/crates/RustQuant_stochastics/src/arithmetic_brownian_motion.rs
+++ b/crates/RustQuant_stochastics/src/arithmetic_brownian_motion.rs
@@ -58,15 +58,17 @@ impl StochasticProcess for ArithmeticBrownianMotion {
 #[cfg(test)]
 mod tests_abm {
     use super::*;
-    use crate::StochasticProcessConfig;
+    use crate::{StochasticProcessConfig, StochasticScheme};
     use RustQuant_math::*;
     use RustQuant_utils::assert_approx_equal;
 
     #[test]
     fn test_arithmetic_brownian_motion() {
         let abm = ArithmeticBrownianMotion::new(0.05, 0.9);
-        let config = StochasticProcessConfig::new(10.0, 0.0, 0.5, 125, 1000, false);
-        let output = abm.euler_maruyama(&config);
+        let config = StochasticProcessConfig::new(
+            10.0, 0.0, 0.5, 125, StochasticScheme::EulerMaruyama, 1000, false, None
+        );
+        let output = abm.monte_carlo(&config);
 
         // let file1 = "./images/ABM1.png";
         // plot_vector((&output.trajectories[0]).clone(), file1).unwrap();

--- a/crates/RustQuant_stochastics/src/black_derman_toy.rs
+++ b/crates/RustQuant_stochastics/src/black_derman_toy.rs
@@ -65,7 +65,7 @@ pub(crate) fn diff(f: &(dyn Fn(f64) -> f64 + Send + Sync), t: f64) -> f64 {
 #[cfg(test)]
 mod tests_black_derman_toy {
     use super::*;
-    use crate::StochasticProcessConfig;
+    use crate::{StochasticProcessConfig, StochasticScheme};
     use RustQuant_math::*;
 
     // fn theta_t(_t: f64) -> f64 {
@@ -82,8 +82,10 @@ mod tests_black_derman_toy {
 
         let hw = BlackDermanToy::new(sigma, theta);
 
-        let config = StochasticProcessConfig::new(0.13, 0.0, 1.0, 100, 1000, false);
-        let output = hw.euler_maruyama(&config);
+        let config = StochasticProcessConfig::new(
+            0.13, 0.0, 1.0, 100, StochasticScheme::EulerMaruyama, 1000, false, None
+        );
+        let output = hw.monte_carlo(&config);
 
         // Test the distribution of the final values.
         let X_T: Vec<f64> = output
@@ -103,8 +105,10 @@ mod tests_black_derman_toy {
         let theta = 1.5;
 
         let hw = BlackDermanToy::new(sigma, theta);
-        let config = StochasticProcessConfig::new(0.13, 0.0, 1.0, 100, 1000, false);
-        let output = hw.euler_maruyama(&config);
+        let config = StochasticProcessConfig::new(
+            0.13, 0.0, 1.0, 100, crate::StochasticScheme::EulerMaruyama, 1000, false, None
+        );
+        let output = hw.monte_carlo(&config);
 
         // Test the distribution of the final values.
         let X_T: Vec<f64> = output

--- a/crates/RustQuant_stochastics/src/black_derman_toy.rs
+++ b/crates/RustQuant_stochastics/src/black_derman_toy.rs
@@ -85,7 +85,7 @@ mod tests_black_derman_toy {
         let config = StochasticProcessConfig::new(
             0.13, 0.0, 1.0, 100, StochasticScheme::EulerMaruyama, 1000, false, None
         );
-        let output = hw.monte_carlo(&config);
+        let output = hw.generate(&config);
 
         // Test the distribution of the final values.
         let X_T: Vec<f64> = output
@@ -108,7 +108,7 @@ mod tests_black_derman_toy {
         let config = StochasticProcessConfig::new(
             0.13, 0.0, 1.0, 100, crate::StochasticScheme::EulerMaruyama, 1000, false, None
         );
-        let output = hw.monte_carlo(&config);
+        let output = hw.generate(&config);
 
         // Test the distribution of the final values.
         let X_T: Vec<f64> = output

--- a/crates/RustQuant_stochastics/src/brownian_motion.rs
+++ b/crates/RustQuant_stochastics/src/brownian_motion.rs
@@ -87,7 +87,7 @@ mod sde_tests {
         let config = StochasticProcessConfig::new(
             0.0, 0.0, 0.5, 100, StochasticScheme::EulerMaruyama, 1000, false, None
         );
-        let output_serial = bm.monte_carlo(&config);
+        let output_serial = bm.generate(&config);
         // let output_parallel = (&bm).euler_maruyama(10.0, 0.0, 0.5, 100, 10, true);
 
         // let file1 = "./images/BM1.png";

--- a/crates/RustQuant_stochastics/src/brownian_motion.rs
+++ b/crates/RustQuant_stochastics/src/brownian_motion.rs
@@ -54,7 +54,7 @@ mod sde_tests {
     // use std::time::Instant;
 
     use super::*;
-    use crate::StochasticProcessConfig;
+    use crate::{StochasticProcessConfig, StochasticScheme};
     use RustQuant_math::*;
     use RustQuant_utils::assert_approx_equal;
 
@@ -84,8 +84,10 @@ mod sde_tests {
         // }
         // assert!(1 == 2);
 
-        let config = StochasticProcessConfig::new(0.0, 0.0, 0.5, 100, 1000, false);
-        let output_serial = bm.euler_maruyama(&config);
+        let config = StochasticProcessConfig::new(
+            0.0, 0.0, 0.5, 100, StochasticScheme::EulerMaruyama, 1000, false, None
+        );
+        let output_serial = bm.monte_carlo(&config);
         // let output_parallel = (&bm).euler_maruyama(10.0, 0.0, 0.5, 100, 10, true);
 
         // let file1 = "./images/BM1.png";

--- a/crates/RustQuant_stochastics/src/constant_elasticity_of_variance.rs
+++ b/crates/RustQuant_stochastics/src/constant_elasticity_of_variance.rs
@@ -67,14 +67,16 @@ impl StochasticProcess for ConstantElasticityOfVariance {
 #[cfg(test)]
 mod tests_cev {
     use super::*;
-    use crate::StochasticProcessConfig;
+    use crate::{StochasticProcessConfig, StochasticScheme};
     use RustQuant_math::*;
 
     #[test]
     fn test_cev_process() {
         let cev = ConstantElasticityOfVariance::new(0.05, 0.9, 0.45);
-        let config = StochasticProcessConfig::new(10.0, 0.0, 0.5, 100, 100, false);
-        let output = cev.euler_maruyama(&config);
+        let config = StochasticProcessConfig::new(
+            10.0, 0.0, 0.5, 100, StochasticScheme::EulerMaruyama, 100, false, None
+        );
+        let output = cev.monte_carlo(&config);
 
         // Test the distribution of the final values.
         let X_T: Vec<f64> = output

--- a/crates/RustQuant_stochastics/src/constant_elasticity_of_variance.rs
+++ b/crates/RustQuant_stochastics/src/constant_elasticity_of_variance.rs
@@ -76,7 +76,7 @@ mod tests_cev {
         let config = StochasticProcessConfig::new(
             10.0, 0.0, 0.5, 100, StochasticScheme::EulerMaruyama, 100, false, None
         );
-        let output = cev.monte_carlo(&config);
+        let output = cev.generate(&config);
 
         // Test the distribution of the final values.
         let X_T: Vec<f64> = output

--- a/crates/RustQuant_stochastics/src/cox_ingersoll_ross.rs
+++ b/crates/RustQuant_stochastics/src/cox_ingersoll_ross.rs
@@ -77,7 +77,7 @@ mod tests_cir {
             10.0, 0.0, 0.5, 100, StochasticScheme::EulerMaruyama, 100, false, None
         );
 
-        let output = cir.monte_carlo(&config);
+        let output = cir.generate(&config);
 
         // Test the distribution of the final values.
         let X_T: Vec<f64> = output

--- a/crates/RustQuant_stochastics/src/cox_ingersoll_ross.rs
+++ b/crates/RustQuant_stochastics/src/cox_ingersoll_ross.rs
@@ -65,7 +65,7 @@ impl StochasticProcess for CoxIngersollRoss {
 #[cfg(test)]
 mod tests_cir {
     use super::*;
-    use crate::StochasticProcessConfig;
+    use crate::{StochasticProcessConfig, StochasticScheme};
     use RustQuant_math::*;
     use RustQuant_utils::assert_approx_equal;
 
@@ -73,9 +73,11 @@ mod tests_cir {
     fn test_cox_ingersoll_ross() {
         let cir = CoxIngersollRoss::new(0.15, 0.45, 0.01);
 
-        let config = StochasticProcessConfig::new(10.0, 0.0, 0.5, 100, 100, false);
+        let config = StochasticProcessConfig::new(
+            10.0, 0.0, 0.5, 100, StochasticScheme::EulerMaruyama, 100, false, None
+        );
 
-        let output = cir.euler_maruyama(&config);
+        let output = cir.monte_carlo(&config);
 
         // Test the distribution of the final values.
         let X_T: Vec<f64> = output

--- a/crates/RustQuant_stochastics/src/extended_vasicek.rs
+++ b/crates/RustQuant_stochastics/src/extended_vasicek.rs
@@ -62,7 +62,7 @@ impl StochasticProcess for ExtendedVasicek {
 #[cfg(test)]
 mod tests_extended_vasicek {
     use super::*;
-    use crate::StochasticProcessConfig;
+    use crate::{StochasticProcessConfig, StochasticScheme};
     use RustQuant_math::*;
     use RustQuant_utils::assert_approx_equal;
 
@@ -81,9 +81,11 @@ mod tests_extended_vasicek {
 
         let ev = ExtendedVasicek::new(alpha, sigma, theta);
 
-        let config = StochasticProcessConfig::new(10.0, 0.0, 1.0, 150, 1000, false);
+        let config = StochasticProcessConfig::new(
+            10.0, 0.0, 1.0, 150, StochasticScheme::EulerMaruyama, 1000, false, None
+        );
 
-        let output = ev.euler_maruyama(&config);
+        let output = ev.monte_carlo(&config);
 
         // Test the distribution of the final values.
         let X_T: Vec<f64> = output

--- a/crates/RustQuant_stochastics/src/extended_vasicek.rs
+++ b/crates/RustQuant_stochastics/src/extended_vasicek.rs
@@ -85,7 +85,7 @@ mod tests_extended_vasicek {
             10.0, 0.0, 1.0, 150, StochasticScheme::EulerMaruyama, 1000, false, None
         );
 
-        let output = ev.monte_carlo(&config);
+        let output = ev.generate(&config);
 
         // Test the distribution of the final values.
         let X_T: Vec<f64> = output

--- a/crates/RustQuant_stochastics/src/fractional_brownian_motion.rs
+++ b/crates/RustQuant_stochastics/src/fractional_brownian_motion.rs
@@ -7,18 +7,8 @@
 //      - LICENSE-MIT.md
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use super::StochasticProcessConfig;
-use crate::process::{StochasticProcess, Trajectories};
-use nalgebra::{DMatrix, DVector, Dim, Dyn, RowDVector};
-use ndarray::{concatenate, prelude::*};
-// use ndarray_rand::{rand::random, RandomExt};
-use ndarray_rand::RandomExt;
-use ndrustfft::{ndfft_par, FftHandler};
-use num::{complex::ComplexDistribution, Complex};
-use rand::Rng;
-use rand::{rngs::StdRng, SeedableRng};
-use rand_distr::StandardNormal;
-use rayon::prelude::*;
+use crate::process::{StochasticProcess, Trajectories, StochasticProcessConfig};
+use crate::fractional_process::{fractional_monte_carlo, FractionalProcessGeneratorMethod};
 
 /// Struct containing the Fractional Brownian Motion parameters.
 #[derive(Debug)]
@@ -50,126 +40,6 @@ impl FractionalBrownianMotion {
     }
 }
 
-/// Method used to generate the Fractional Brownian Motion.
-#[derive(Debug)]
-pub enum FractionalProcessGeneratorMethod {
-    /// Chooses the Cholesky decomposition method.
-    CHOLESKY,
-    /// Chooses the Davies-Harte method.
-    FFT,
-}
-
-impl FractionalBrownianMotion {
-    /// Autocovariance function (ACF).
-    fn acf_vector(&self, n: usize) -> RowDVector<f64> {
-        let h = self.hurst;
-
-        let mut v = RowDVector::<f64>::zeros(n);
-        v[0] = 1.0;
-
-        for i in 1..n {
-            let idx = i as f64;
-
-            v[i] = 0.5
-                * ((idx + 1.0).powf(2.0 * h) - 2.0 * idx.powf(2.0 * h) + (idx - 1.0).powf(2.0 * h));
-        }
-
-        v
-    }
-
-    /// Autocovariance matrix.
-    fn acf_matrix_sqrt(&self, n: usize) -> DMatrix<f64> {
-        let acf_vector = self.acf_vector(n);
-
-        let mut m = DMatrix::<f64>::from_diagonal_element_generic(
-            Dyn::from_usize(n),
-            Dyn::from_usize(n),
-            acf_vector[0],
-        );
-
-        for i in 1..n {
-            for j in 0..i {
-                m[(i, j)] = acf_vector[i - j];
-            }
-        }
-
-        m.cholesky().unwrap().l()
-    }
-
-    /// Fractional Gaussian noise.
-    pub fn fgn_cholesky(&self, n: usize, t_n: f64) -> Vec<f64> {
-        let acf_sqrt = self.acf_matrix_sqrt(n);
-        let noise = rand::thread_rng()
-            .sample_iter::<f64, StandardNormal>(StandardNormal)
-            .take(n)
-            .collect();
-        let noise = DVector::<f64>::from_vec(noise);
-        let noise = (acf_sqrt * noise).transpose() * (1.0 * t_n / n as f64).powf(self.hurst);
-
-        noise.data.as_vec().clone()
-    }
-
-    /// Seedable Fractional Gaussian noise.
-    pub fn seedable_fgn_cholesky(&self, n: usize, t_n: f64, seed: u64) -> Vec<f64> {
-        let acf_sqrt = self.acf_matrix_sqrt(n);
-        let noise = StdRng::seed_from_u64(seed)
-            .sample_iter::<f64, StandardNormal>(StandardNormal)
-            .take(n)
-            .collect();
-        let noise = DVector::<f64>::from_vec(noise);
-        let noise = (acf_sqrt * noise).transpose() * (1.0 * t_n / n as f64).powf(self.hurst);
-
-        noise.data.as_vec().clone()
-    }
-
-    /// Fractional Gaussian noise via FFT.
-    pub fn fgn_fft(&self, n: usize, t_n: f64) -> Vec<f64> {
-        if !(0.0..=1.0).contains(&self.hurst) {
-            panic!("Hurst parameter must be between 0 and 1");
-        }
-        let mut r = Array1::linspace(0.0, n as f64, n + 1);
-        r.par_mapv_inplace(|x| {
-            if x == 0.0 {
-                1.0
-            } else {
-                0.5 * ((x + 1.0).powf(2.0 * self.hurst) - 2.0 * (x).powf(2.0 * self.hurst)
-                    + (x - 1.0).powf(2.0 * self.hurst))
-            }
-        });
-        let r = concatenate(
-            Axis(0),
-            #[allow(clippy::reversed_empty_ranges)]
-            &[r.view(), r.slice(s![..;-1]).slice(s![1..-1]).view()],
-        )
-        .unwrap();
-        let mut data = Array1::<Complex<f64>>::zeros(r.len());
-        for (i, v) in r.iter().enumerate() {
-            data[i] = Complex::new(*v, 0.0);
-        }
-        let r_fft = FftHandler::new(r.len());
-        let mut sqrt_eigenvalues = Array1::<Complex<f64>>::zeros(r.len());
-
-        ndfft_par(&data, &mut sqrt_eigenvalues, &r_fft, 0);
-
-        sqrt_eigenvalues.par_mapv_inplace(|x| Complex::new((x.re / (2.0 * n as f64)).sqrt(), x.im));
-
-        let rnd = Array1::<Complex<f64>>::random(
-            2 * n,
-            ComplexDistribution::new(StandardNormal, StandardNormal),
-        );
-        let fgn = &sqrt_eigenvalues * &rnd;
-        let fft_handler = FftHandler::new(2 * n);
-        let mut fgn_fft = Array1::<Complex<f64>>::zeros(2 * n);
-
-        ndfft_par(&fgn, &mut fgn_fft, &fft_handler, 0);
-
-        let fgn = fgn_fft
-            .slice(s![1..n + 1])
-            .mapv(|x: Complex<f64>| (x.re * (n as f64).powf(-self.hurst)) * t_n.powf(self.hurst));
-        fgn.to_vec()
-    }
-}
-
 impl StochasticProcess for FractionalBrownianMotion {
     fn drift(&self, _x: f64, _t: f64) -> f64 {
         0.0
@@ -187,74 +57,8 @@ impl StochasticProcess for FractionalBrownianMotion {
         vec![self.hurst]
     }
 
-    fn euler_maruyama(&self, config: &StochasticProcessConfig) -> Trajectories {
-        let (x_0, t_0, t_n, n_steps, m_paths, parallel) = config.unpack();
-
-        assert!(t_0 < t_n);
-
-        let dt: f64 = (t_n - t_0) / (n_steps as f64);
-
-        // Initialise empty paths and fill in the time points.
-        let mut paths = vec![vec![x_0; n_steps + 1]; m_paths];
-        let times: Vec<f64> = (0..=n_steps).map(|t| t_0 + dt * (t as f64)).collect();
-
-        let path_generator = |path: &mut Vec<f64>| {
-            let fgn = match self.method {
-                FractionalProcessGeneratorMethod::FFT => self.fgn_fft(n_steps, t_n),
-                FractionalProcessGeneratorMethod::CHOLESKY => self.fgn_cholesky(n_steps, t_n),
-            };
-
-            for t in 0..n_steps {
-                path[t + 1] = path[t]
-                    + self.drift(path[t], times[t]) * dt
-                    + self.diffusion(path[t], times[t]) * fgn[t];
-            }
-        };
-
-        if parallel {
-            paths.par_iter_mut().for_each(path_generator);
-        } else {
-            paths.iter_mut().for_each(path_generator);
-        }
-
-        Trajectories { times, paths }
-    }
-
-    fn seedable_euler_maruyama(
-        &self,
-        x_0: f64,
-        t_0: f64,
-        t_n: f64,
-        n_steps: usize,
-        m_paths: usize,
-        parallel: bool,
-        seed: u64,
-    ) -> Trajectories {
-        assert!(t_0 < t_n);
-
-        let dt: f64 = (t_n - t_0) / (n_steps as f64);
-
-        // Initialise empty paths and fill in the time points.
-        let mut paths = vec![vec![x_0; n_steps + 1]; m_paths];
-        let times: Vec<f64> = (0..=n_steps).map(|t| t_0 + dt * (t as f64)).collect();
-
-        let path_generator = |path: &mut Vec<f64>| {
-            let fgn = self.seedable_fgn_cholesky(n_steps, t_n, seed);
-
-            for t in 0..n_steps {
-                path[t + 1] = path[t]
-                    + self.drift(path[t], times[t]) * dt
-                    + self.diffusion(path[t], times[t]) * fgn[t];
-            }
-        };
-
-        if parallel {
-            paths.par_iter_mut().for_each(path_generator);
-        } else {
-            paths.iter_mut().for_each(path_generator);
-        }
-
-        Trajectories { times, paths }
+    fn monte_carlo(&self, config: &StochasticProcessConfig) -> Trajectories {
+        fractional_monte_carlo(self, config, &self.method, self.hurst)
     }
 }
 
@@ -262,69 +66,21 @@ impl StochasticProcess for FractionalBrownianMotion {
 // TESTS
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+
 #[cfg(test)]
 mod test_fractional_brownian_motion {
     use super::*;
-    use crate::StochasticProcessConfig;
+    use crate::{StochasticProcessConfig, StochasticScheme};
     use RustQuant_math::*;
-    use RustQuant_ml::{Decomposition, LinearRegressionInput};
     use RustQuant_utils::assert_approx_equal;
-
-    fn higuchi_fd(x: &Vec<f64>, kmax: usize) -> f64 {
-        let n_times = x.len();
-
-        let mut lk = vec![0.0; kmax];
-        let mut x_reg = vec![0.0; kmax];
-        let mut y_reg = vec![0.0; kmax];
-
-        for k in 1..=kmax {
-            let mut lm = vec![0.0; k];
-
-            for m in 0..k {
-                let mut ll = 0.0;
-                let n_max = ((n_times - m - 1) as f64 / k as f64).floor() as usize;
-
-                for j in 1..n_max {
-                    ll += (x[m + j * k] - x[m + (j - 1) * k]).abs();
-                }
-
-                ll /= k as f64;
-                ll *= (n_times - 1) as f64 / (k * n_max) as f64;
-                lm[m] = ll;
-            }
-
-            lk[k - 1] = lm.iter().sum::<f64>() / k as f64;
-            x_reg[k - 1] = (1.0 / k as f64).ln();
-            y_reg[k - 1] = lk[k - 1].ln();
-        }
-
-        let x_reg = DMatrix::from_vec(kmax, 1, x_reg);
-        let y_reg = DVector::from_vec(y_reg);
-        let linear_regression = LinearRegressionInput::new(x_reg, y_reg);
-        let regression_result = linear_regression.fit(Decomposition::None).unwrap();
-
-        regression_result.coefficients[0]
-    }
-
-    #[test]
-    fn test_chol() {
-        let fbm = FractionalBrownianMotion::new(0.7, FractionalProcessGeneratorMethod::FFT);
-        let hursts = vec![0.1, 0.3, 0.5, 0.7, 0.9];
-
-        for hurst in hursts {
-            let fbm = FractionalBrownianMotion::fgn_cholesky(&fbm, 1000, 1.0);
-            let higuchi_fd = higuchi_fd(&fbm.to_vec(), 10);
-            let est_hurst = 2.0 - higuchi_fd;
-            print!("hurst: {}, higuchi_fd: {}\n", hurst, est_hurst);
-            assert!(est_hurst - hurst < 0.05);
-        }
-    }
 
     #[test]
     fn test_brownian_motion() {
         let fbm = FractionalBrownianMotion::new(0.7, FractionalProcessGeneratorMethod::FFT);
-        let config = StochasticProcessConfig::new(0.0, 0.0, 0.5, 100, 1000, false);
-        let output_serial = fbm.euler_maruyama(&config);
+        let config = StochasticProcessConfig::new(
+            0.0, 0.0, 0.5,100, StochasticScheme::EulerMaruyama,1000, false, None
+        );
+        let output_serial = fbm.monte_carlo(&config);
         // let output_parallel = (&bm).euler_maruyama(10.0, 0.0, 0.5, 100, 10, true);
 
         // Test the distribution of the final values.

--- a/crates/RustQuant_stochastics/src/fractional_brownian_motion.rs
+++ b/crates/RustQuant_stochastics/src/fractional_brownian_motion.rs
@@ -8,7 +8,7 @@
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 use crate::process::{StochasticProcess, Trajectories, StochasticProcessConfig};
-use crate::fractional_process::{fractional_monte_carlo, FractionalProcessGeneratorMethod};
+use crate::fractional_process::{simulate_fractional_stochastic_process, FractionalProcessGeneratorMethod};
 
 /// Struct containing the Fractional Brownian Motion parameters.
 #[derive(Debug)]
@@ -57,8 +57,8 @@ impl StochasticProcess for FractionalBrownianMotion {
         vec![self.hurst]
     }
 
-    fn monte_carlo(&self, config: &StochasticProcessConfig) -> Trajectories {
-        fractional_monte_carlo(self, config, &self.method, self.hurst)
+    fn generate(&self, config: &StochasticProcessConfig) -> Trajectories {
+        simulate_fractional_stochastic_process(self, config, &self.method, self.hurst)
     }
 }
 
@@ -80,7 +80,7 @@ mod test_fractional_brownian_motion {
         let config = StochasticProcessConfig::new(
             0.0, 0.0, 0.5,100, StochasticScheme::EulerMaruyama,1000, false, None
         );
-        let output_serial = fbm.monte_carlo(&config);
+        let output_serial = fbm.generate(&config);
         // let output_parallel = (&bm).euler_maruyama(10.0, 0.0, 0.5, 100, 10, true);
 
         // Test the distribution of the final values.

--- a/crates/RustQuant_stochastics/src/fractional_cox_ingersoll_ross.rs
+++ b/crates/RustQuant_stochastics/src/fractional_cox_ingersoll_ross.rs
@@ -8,7 +8,7 @@
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 use crate::process::{StochasticProcessConfig, StochasticProcess, Trajectories};
-use crate::fractional_process::{fractional_monte_carlo, FractionalProcessGeneratorMethod};
+use crate::fractional_process::{simulate_fractional_stochastic_process, FractionalProcessGeneratorMethod};
 use crate::model_parameter::ModelParameter;
 
 /// Struct containing the Ornstein-Uhlenbeck process parameters.
@@ -73,8 +73,8 @@ impl StochasticProcess for FractionalCoxIngersollRoss {
         ]
     }
 
-    fn monte_carlo(&self, config: &StochasticProcessConfig) -> Trajectories {
-        fractional_monte_carlo(self, config, &self.method, self.hurst)
+    fn generate(&self, config: &StochasticProcessConfig) -> Trajectories {
+        simulate_fractional_stochastic_process(self, config, &self.method, self.hurst)
     }
 }
 
@@ -103,7 +103,7 @@ mod test_fractional_cir {
         );
 
         #[allow(dead_code)]
-        let _output = fou.monte_carlo(&config);
+        let _output = fou.generate(&config);
 
         std::result::Result::Ok(())
     }

--- a/crates/RustQuant_stochastics/src/fractional_cox_ingersoll_ross.rs
+++ b/crates/RustQuant_stochastics/src/fractional_cox_ingersoll_ross.rs
@@ -7,14 +7,9 @@
 //      - LICENSE-MIT.md
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use super::{
-    fractional_brownian_motion::FractionalProcessGeneratorMethod,
-    process::{StochasticProcess, Trajectories},
-    StochasticProcessConfig,
-};
-use crate::fractional_brownian_motion::FractionalBrownianMotion;
+use crate::process::{StochasticProcessConfig, StochasticProcess, Trajectories};
+use crate::fractional_process::{fractional_monte_carlo, FractionalProcessGeneratorMethod};
 use crate::model_parameter::ModelParameter;
-use rayon::prelude::*;
 
 /// Struct containing the Ornstein-Uhlenbeck process parameters.
 pub struct FractionalCoxIngersollRoss {
@@ -79,47 +74,7 @@ impl StochasticProcess for FractionalCoxIngersollRoss {
     }
 
     fn monte_carlo(&self, config: &StochasticProcessConfig) -> Trajectories {
-        let (t_0, x_0, t_n, n_steps, m_paths, parallel) = config.unpack();
-
-        let fgn = match self.method {
-            FractionalProcessGeneratorMethod::CHOLESKY => {
-                let fbm = FractionalBrownianMotion::new(
-                    self.hurst,
-                    FractionalProcessGeneratorMethod::CHOLESKY,
-                );
-                FractionalBrownianMotion::fgn_cholesky(&fbm, n_steps, t_n)
-            }
-            FractionalProcessGeneratorMethod::FFT => {
-                let fbm = FractionalBrownianMotion::new(
-                    self.hurst,
-                    FractionalProcessGeneratorMethod::FFT,
-                );
-                // FractionalBrownianMotion::fgn_fft(&fbm, n_steps, t_n)
-                fbm.fgn_fft(n_steps, t_n)
-            }
-        };
-
-        let dt: f64 = (t_n - t_0) / (n_steps as f64);
-
-        // Initialise empty paths and fill in the time points.
-        let mut paths = vec![vec![x_0; n_steps + 1]; m_paths];
-        let times: Vec<f64> = (0..=n_steps).map(|t| t_0 + dt * (t as f64)).collect();
-
-        let path_generator = |path: &mut Vec<f64>| {
-            for t in 0..n_steps {
-                path[t + 1] = path[t]
-                    + self.drift(path[t], times[t]) * dt
-                    + self.diffusion(path[t], times[t]) * fgn[t];
-            }
-        };
-
-        if parallel {
-            paths.par_iter_mut().for_each(path_generator);
-        } else {
-            paths.iter_mut().for_each(path_generator);
-        }
-
-        Trajectories { times, paths }
+        fractional_monte_carlo(self, config, &self.method, self.hurst)
     }
 }
 

--- a/crates/RustQuant_stochastics/src/fractional_cox_ingersoll_ross.rs
+++ b/crates/RustQuant_stochastics/src/fractional_cox_ingersoll_ross.rs
@@ -78,7 +78,7 @@ impl StochasticProcess for FractionalCoxIngersollRoss {
         ]
     }
 
-    fn euler_maruyama(&self, config: &StochasticProcessConfig) -> Trajectories {
+    fn monte_carlo(&self, config: &StochasticProcessConfig) -> Trajectories {
         let (t_0, x_0, t_n, n_steps, m_paths, parallel) = config.unpack();
 
         let fgn = match self.method {
@@ -94,7 +94,8 @@ impl StochasticProcess for FractionalCoxIngersollRoss {
                     self.hurst,
                     FractionalProcessGeneratorMethod::FFT,
                 );
-                FractionalBrownianMotion::fgn_fft(&fbm, n_steps, t_n)
+                // FractionalBrownianMotion::fgn_fft(&fbm, n_steps, t_n)
+                fbm.fgn_fft(n_steps, t_n)
             }
         };
 
@@ -129,7 +130,7 @@ impl StochasticProcess for FractionalCoxIngersollRoss {
 #[cfg(test)]
 mod test_fractional_cir {
     use super::*;
-    use crate::fractional_ornstein_uhlenbeck::FractionalOrnsteinUhlenbeck;
+    use crate::{fractional_ornstein_uhlenbeck::FractionalOrnsteinUhlenbeck, StochasticScheme};
 
     #[test]
     #[ignore = "Hard to test."]
@@ -142,10 +143,12 @@ mod test_fractional_cir {
             FractionalProcessGeneratorMethod::FFT,
         );
 
-        let config = StochasticProcessConfig::new(10.0, 0.0, 0.5, 100, 100, false);
+        let config = StochasticProcessConfig::new(
+            10.0, 0.0, 0.5, 100, StochasticScheme::EulerMaruyama, 100, false, None
+        );
 
         #[allow(dead_code)]
-        let _output = fou.euler_maruyama(&config);
+        let _output = fou.monte_carlo(&config);
 
         std::result::Result::Ok(())
     }

--- a/crates/RustQuant_stochastics/src/fractional_ornstein_uhlenbeck.rs
+++ b/crates/RustQuant_stochastics/src/fractional_ornstein_uhlenbeck.rs
@@ -79,7 +79,7 @@ impl StochasticProcess for FractionalOrnsteinUhlenbeck {
         ]
     }
 
-    fn euler_maruyama(&self, config: &StochasticProcessConfig) -> Trajectories {
+    fn monte_carlo(&self, config: &StochasticProcessConfig) -> Trajectories {
         let (x_0, t_0, t_n, n_steps, m_paths, parallel) = config.unpack();
 
         let fgn = match self.method {
@@ -129,6 +129,8 @@ impl StochasticProcess for FractionalOrnsteinUhlenbeck {
 
 #[cfg(test)]
 mod tests_fractional_ornstein_uhlenbeck {
+    use crate::StochasticScheme;
+
     use super::*;
 
     #[test]
@@ -142,8 +144,10 @@ mod tests_fractional_ornstein_uhlenbeck {
             FractionalProcessGeneratorMethod::FFT,
         );
 
-        let config = StochasticProcessConfig::new(10.0, 0.0, 0.5, 100, 100, false);
+        let config = StochasticProcessConfig::new(
+            10.0, 0.0, 0.5, 100, StochasticScheme::EulerMaruyama, 100, false, None
+        );
         #[allow(dead_code)]
-        let _output = fou.euler_maruyama(&config);
+        let _output = fou.monte_carlo(&config);
     }
 }

--- a/crates/RustQuant_stochastics/src/fractional_ornstein_uhlenbeck.rs
+++ b/crates/RustQuant_stochastics/src/fractional_ornstein_uhlenbeck.rs
@@ -8,7 +8,7 @@
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 use crate::process::{StochasticProcessConfig, StochasticProcess, Trajectories};
-use crate::fractional_process::{fractional_monte_carlo, FractionalProcessGeneratorMethod};
+use crate::fractional_process::{simulate_fractional_stochastic_process, FractionalProcessGeneratorMethod};
 use crate::model_parameter::ModelParameter;
 
 /// Struct containing the Ornstein-Uhlenbeck process parameters.
@@ -74,8 +74,8 @@ impl StochasticProcess for FractionalOrnsteinUhlenbeck {
         ]
     }
 
-    fn monte_carlo(&self, config: &StochasticProcessConfig) -> Trajectories {
-        fractional_monte_carlo(self, config, &self.method, self.hurst)
+    fn generate(&self, config: &StochasticProcessConfig) -> Trajectories {
+        simulate_fractional_stochastic_process(self, config, &self.method, self.hurst)
     }
 }
 
@@ -104,6 +104,6 @@ mod tests_fractional_ornstein_uhlenbeck {
             10.0, 0.0, 0.5, 100, StochasticScheme::EulerMaruyama, 100, false, None
         );
         #[allow(dead_code)]
-        let _output = fou.monte_carlo(&config);
+        let _output = fou.generate(&config);
     }
 }

--- a/crates/RustQuant_stochastics/src/fractional_ornstein_uhlenbeck.rs
+++ b/crates/RustQuant_stochastics/src/fractional_ornstein_uhlenbeck.rs
@@ -7,14 +7,9 @@
 //      - LICENSE-MIT.md
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use super::StochasticProcessConfig;
-use crate::fractional_brownian_motion::FractionalProcessGeneratorMethod;
+use crate::process::{StochasticProcessConfig, StochasticProcess, Trajectories};
+use crate::fractional_process::{fractional_monte_carlo, FractionalProcessGeneratorMethod};
 use crate::model_parameter::ModelParameter;
-use crate::{
-    fractional_brownian_motion::FractionalBrownianMotion,
-    process::{StochasticProcess, Trajectories},
-};
-use rayon::prelude::*;
 
 /// Struct containing the Ornstein-Uhlenbeck process parameters.
 pub struct FractionalOrnsteinUhlenbeck {
@@ -80,46 +75,7 @@ impl StochasticProcess for FractionalOrnsteinUhlenbeck {
     }
 
     fn monte_carlo(&self, config: &StochasticProcessConfig) -> Trajectories {
-        let (x_0, t_0, t_n, n_steps, m_paths, parallel) = config.unpack();
-
-        let fgn = match self.method {
-            FractionalProcessGeneratorMethod::CHOLESKY => {
-                let fbm = FractionalBrownianMotion::new(
-                    self.hurst,
-                    FractionalProcessGeneratorMethod::CHOLESKY,
-                );
-                FractionalBrownianMotion::fgn_cholesky(&fbm, n_steps, t_n)
-            }
-            FractionalProcessGeneratorMethod::FFT => {
-                let fbm = FractionalBrownianMotion::new(
-                    self.hurst,
-                    FractionalProcessGeneratorMethod::FFT,
-                );
-                FractionalBrownianMotion::fgn_fft(&fbm, n_steps, t_n)
-            }
-        };
-
-        let dt: f64 = (t_n - t_0) / (n_steps as f64);
-
-        // Initialise empty paths and fill in the time points.
-        let mut paths = vec![vec![x_0; n_steps + 1]; m_paths];
-        let times: Vec<f64> = (0..=n_steps).map(|t| t_0 + dt * (t as f64)).collect();
-
-        let path_generator = |path: &mut Vec<f64>| {
-            for t in 0..n_steps {
-                path[t + 1] = path[t]
-                    + self.drift(path[t], times[t]) * dt
-                    + self.diffusion(path[t], times[t]) * fgn[t];
-            }
-        };
-
-        if parallel {
-            paths.par_iter_mut().for_each(path_generator);
-        } else {
-            paths.iter_mut().for_each(path_generator);
-        }
-
-        Trajectories { times, paths }
+        fractional_monte_carlo(self, config, &self.method, self.hurst)
     }
 }
 

--- a/crates/RustQuant_stochastics/src/fractional_process.rs
+++ b/crates/RustQuant_stochastics/src/fractional_process.rs
@@ -1,5 +1,14 @@
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// RustQuant: A Rust library for quantitative finance tools.
+// Copyright (C) 2023 https://github.com/avhz
+// Dual licensed under Apache 2.0 and MIT.
+// See:
+//      - LICENSE-APACHE.md
+//      - LICENSE-MIT.md
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 use super::process::*;
-use crate::monte_carlo::run_monte_carlo;
+use crate::simulation::simulate_stochatic_process;
 use rand::{rngs::StdRng, SeedableRng};
 use rand_distr::StandardNormal;
 use nalgebra::{DMatrix, DVector, Dim, Dyn, RowDVector};
@@ -19,7 +28,7 @@ pub enum FractionalProcessGeneratorMethod {
 }
 
 /// Function to run the monte carlo method for the fractional stochastic process.
-pub(crate) fn fractional_monte_carlo<T: StochasticProcess>(
+pub(crate) fn simulate_fractional_stochastic_process<T: StochasticProcess>(
     stochastic_process: &T, 
     config: &StochasticProcessConfig, 
     method: &FractionalProcessGeneratorMethod, 
@@ -29,7 +38,7 @@ pub(crate) fn fractional_monte_carlo<T: StochasticProcess>(
         FractionalProcessGeneratorMethod::CHOLESKY => fgn_cholesky,
         FractionalProcessGeneratorMethod::FFT => fgn_fft
     };
-    run_monte_carlo(stochastic_process, &config, None,Some((fgn, hurst)))
+    simulate_stochatic_process(stochastic_process, &config, None,Some((fgn, hurst)))
 }
 
 /// Autocovariance function (ACF).

--- a/crates/RustQuant_stochastics/src/fractional_process.rs
+++ b/crates/RustQuant_stochastics/src/fractional_process.rs
@@ -1,0 +1,190 @@
+use super::process::*;
+use crate::monte_carlo::run_monte_carlo;
+use rand::{rngs::StdRng, SeedableRng};
+use rand_distr::StandardNormal;
+use nalgebra::{DMatrix, DVector, Dim, Dyn, RowDVector};
+use ndrustfft::{ndfft_par, FftHandler};
+use num::{complex::ComplexDistribution, Complex};
+use ndarray::{concatenate, prelude::*};
+use ndarray_rand::RandomExt;
+use rand::Rng;
+
+/// Method used to generate the Fractional Brownian Motion.
+#[derive(Debug)]
+pub enum FractionalProcessGeneratorMethod {
+    /// Chooses the Cholesky decomposition method.
+    CHOLESKY,
+    /// Chooses the Davies-Harte method.
+    FFT,
+}
+
+/// Function to run the monte carlo method for the fractional stochastic process.
+pub(crate) fn fractional_monte_carlo<T: StochasticProcess>(
+    stochastic_process: &T, 
+    config: &StochasticProcessConfig, 
+    method: &FractionalProcessGeneratorMethod, 
+    hurst: f64
+) -> Trajectories {
+    let fgn = match method {
+        FractionalProcessGeneratorMethod::CHOLESKY => fgn_cholesky,
+        FractionalProcessGeneratorMethod::FFT => fgn_fft
+    };
+    run_monte_carlo(stochastic_process, &config, None,Some((fgn, hurst)))
+}
+
+/// Autocovariance function (ACF).
+fn acf_vector(hurst: f64, n: usize) -> RowDVector<f64> {
+    let h = hurst;
+
+    let mut v = RowDVector::<f64>::zeros(n);
+    v[0] = 1.0;
+
+    for i in 1..n {
+        let idx = i as f64;
+
+        v[i] = 0.5
+            * ((idx + 1.0).powf(2.0 * h) - 2.0 * idx.powf(2.0 * h) + (idx - 1.0).powf(2.0 * h));
+    }
+
+    v
+}
+
+/// Autocovariance matrix.
+fn acf_matrix_sqrt(hurst: f64, n: usize) -> DMatrix<f64> {
+    let acf_vector = acf_vector(hurst, n);
+
+    let mut m = DMatrix::<f64>::from_diagonal_element_generic(
+        Dyn::from_usize(n),
+        Dyn::from_usize(n),
+        acf_vector[0],
+    );
+
+    for i in 1..n {
+        for j in 0..i {
+            m[(i, j)] = acf_vector[i - j];
+        }
+    }
+
+    m.cholesky().unwrap().l()
+}
+
+/// Fractional Gaussian noise.
+pub fn fgn_cholesky(hurst: f64, n: usize, t_n: f64, seed: Option<u64>) -> Vec<f64> {
+    let acf_sqrt = acf_matrix_sqrt(hurst, n);
+    let noise = match seed {
+        Some(seed) => StdRng::seed_from_u64(seed),
+        None => StdRng::from_entropy()
+    };
+
+    let noise = noise.sample_iter::<f64, StandardNormal>(StandardNormal)
+    .take(n)
+    .collect();
+    let noise = DVector::<f64>::from_vec(noise);
+    let noise = (acf_sqrt * noise).transpose() * (1.0 * t_n / n as f64).powf(hurst);
+
+    noise.data.as_vec().clone()
+}
+
+/// Fractional Gaussian noise via FFT.
+pub fn fgn_fft(hurst: f64, n: usize, t_n: f64, _: Option<u64>) -> Vec<f64> {
+    if !(0.0..=1.0).contains(&hurst) {
+        panic!("Hurst parameter must be between 0 and 1");
+    }
+    let mut r = Array1::linspace(0.0, n as f64, n + 1);
+    r.par_mapv_inplace(|x| {
+        if x == 0.0 {
+            1.0
+        } else {
+            0.5 * ((x + 1.0).powf(2.0 * hurst) - 2.0 * (x).powf(2.0 * hurst)
+                + (x - 1.0).powf(2.0 * hurst))
+        }
+    });
+    let r = concatenate(
+        Axis(0),
+        #[allow(clippy::reversed_empty_ranges)]
+        &[r.view(), r.slice(s![..;-1]).slice(s![1..-1]).view()],
+    )
+    .unwrap();
+    let mut data = Array1::<Complex<f64>>::zeros(r.len());
+    for (i, v) in r.iter().enumerate() {
+        data[i] = Complex::new(*v, 0.0);
+    }
+    let r_fft = FftHandler::new(r.len());
+    let mut sqrt_eigenvalues = Array1::<Complex<f64>>::zeros(r.len());
+
+    ndfft_par(&data, &mut sqrt_eigenvalues, &r_fft, 0);
+
+    sqrt_eigenvalues.par_mapv_inplace(|x| Complex::new((x.re / (2.0 * n as f64)).sqrt(), x.im));
+
+    let rnd = Array1::<Complex<f64>>::random(
+        2 * n,
+        ComplexDistribution::new(StandardNormal, StandardNormal),
+    );
+    let fgn = &sqrt_eigenvalues * &rnd;
+    let fft_handler = FftHandler::new(2 * n);
+    let mut fgn_fft = Array1::<Complex<f64>>::zeros(2 * n);
+
+    ndfft_par(&fgn, &mut fgn_fft, &fft_handler, 0);
+
+    let fgn = fgn_fft
+        .slice(s![1..n + 1])
+        .mapv(|x: Complex<f64>| (x.re * (n as f64).powf(-hurst)) * t_n.powf(hurst));
+    fgn.to_vec()
+}
+
+#[cfg(test)]
+mod test_fractional_brownian_motion {
+    use super::*;
+    use RustQuant_ml::{Decomposition, LinearRegressionInput};
+    use nalgebra::{DMatrix, DVector};
+
+    fn higuchi_fd(x: &Vec<f64>, kmax: usize) -> f64 {
+        let n_times = x.len();
+
+        let mut lk = vec![0.0; kmax];
+        let mut x_reg = vec![0.0; kmax];
+        let mut y_reg = vec![0.0; kmax];
+
+        for k in 1..=kmax {
+            let mut lm = vec![0.0; k];
+
+            for m in 0..k {
+                let mut ll = 0.0;
+                let n_max = ((n_times - m - 1) as f64 / k as f64).floor() as usize;
+
+                for j in 1..n_max {
+                    ll += (x[m + j * k] - x[m + (j - 1) * k]).abs();
+                }
+
+                ll /= k as f64;
+                ll *= (n_times - 1) as f64 / (k * n_max) as f64;
+                lm[m] = ll;
+            }
+
+            lk[k - 1] = lm.iter().sum::<f64>() / k as f64;
+            x_reg[k - 1] = (1.0 / k as f64).ln();
+            y_reg[k - 1] = lk[k - 1].ln();
+        }
+
+        let x_reg = DMatrix::from_vec(kmax, 1, x_reg);
+        let y_reg = DVector::from_vec(y_reg);
+        let linear_regression = LinearRegressionInput::new(x_reg, y_reg);
+        let regression_result = linear_regression.fit(Decomposition::None).unwrap();
+
+        regression_result.coefficients[0]
+    }
+
+    #[test]
+    fn test_chol() {
+        let hursts = vec![0.1, 0.3, 0.5, 0.7, 0.9];
+
+        for hurst in hursts {
+            let fbm = fgn_cholesky(0.7, 1000, 1.0, None);
+            let higuchi_fd = higuchi_fd(&fbm.to_vec(), 10);
+            let est_hurst = 2.0 - higuchi_fd;
+            print!("hurst: {}, higuchi_fd: {}\n", hurst, est_hurst);
+            assert!(est_hurst - hurst < 0.05);
+        }
+    }
+
+}

--- a/crates/RustQuant_stochastics/src/geometric_brownian_bridge.rs
+++ b/crates/RustQuant_stochastics/src/geometric_brownian_bridge.rs
@@ -77,7 +77,7 @@ impl StochasticProcess for GeometricBrownianBridge {
 #[cfg(test)]
 mod tests_gbm_bridge {
     use super::*;
-    use crate::StochasticProcessConfig;
+    use crate::{StochasticProcessConfig, StochasticScheme};
     use RustQuant_math::*;
     use RustQuant_utils::assert_approx_equal;
 
@@ -86,9 +86,11 @@ mod tests_gbm_bridge {
     fn test_geometric_brownian_motion_bridge() {
         let gbm = GeometricBrownianBridge::new(0.05, 0.9, 10.0, 0.5);
 
-        let config = StochasticProcessConfig::new(10.0, 0.0, 0.5, 125, 10000, false);
+        let config = StochasticProcessConfig::new(
+            10.0, 0.0, 0.5, 125, StochasticScheme::EulerMaruyama, 10000, false, None
+        );
 
-        let output = gbm.euler_maruyama(&config);
+        let output = gbm.monte_carlo(&config);
 
         // Test the distribution of the final values.
         let X_T: Vec<f64> = output

--- a/crates/RustQuant_stochastics/src/geometric_brownian_bridge.rs
+++ b/crates/RustQuant_stochastics/src/geometric_brownian_bridge.rs
@@ -90,7 +90,7 @@ mod tests_gbm_bridge {
             10.0, 0.0, 0.5, 125, StochasticScheme::EulerMaruyama, 10000, false, None
         );
 
-        let output = gbm.monte_carlo(&config);
+        let output = gbm.generate(&config);
 
         // Test the distribution of the final values.
         let X_T: Vec<f64> = output

--- a/crates/RustQuant_stochastics/src/geometric_brownian_motion.rs
+++ b/crates/RustQuant_stochastics/src/geometric_brownian_motion.rs
@@ -80,7 +80,7 @@ mod tests_gbm {
         let config = StochasticProcessConfig::new(
             10.0, 0.0, 0.5, 125, StochasticScheme::EulerMaruyama, 10000, false, None
         );
-        let output = gbm.monte_carlo(&config);
+        let output = gbm.generate(&config);
 
         // Test the distribution of the final values.
         let X_T: Vec<f64> = output

--- a/crates/RustQuant_stochastics/src/geometric_brownian_motion.rs
+++ b/crates/RustQuant_stochastics/src/geometric_brownian_motion.rs
@@ -69,7 +69,7 @@ impl StochasticProcess for GeometricBrownianMotion {
 #[cfg(test)]
 mod tests_gbm {
     use super::*;
-    use crate::StochasticProcessConfig;
+    use crate::{StochasticProcessConfig, StochasticScheme};
     use RustQuant_math::*;
     use RustQuant_utils::assert_approx_equal;
 
@@ -77,8 +77,10 @@ mod tests_gbm {
     fn test_geometric_brownian_motion() {
         let gbm = GeometricBrownianMotion::new(0.05, 0.9);
 
-        let config = StochasticProcessConfig::new(10.0, 0.0, 0.5, 125, 10000, false);
-        let output = gbm.euler_maruyama(&config);
+        let config = StochasticProcessConfig::new(
+            10.0, 0.0, 0.5, 125, StochasticScheme::EulerMaruyama, 10000, false, None
+        );
+        let output = gbm.monte_carlo(&config);
 
         // Test the distribution of the final values.
         let X_T: Vec<f64> = output

--- a/crates/RustQuant_stochastics/src/ho_lee.rs
+++ b/crates/RustQuant_stochastics/src/ho_lee.rs
@@ -56,7 +56,7 @@ impl StochasticProcess for HoLee {
 #[cfg(test)]
 mod tests_ho_lee {
     use super::*;
-    use crate::StochasticProcessConfig;
+    use crate::{StochasticProcessConfig, StochasticScheme};
     use RustQuant_math::*;
     use RustQuant_utils::assert_approx_equal;
     // Test a simple case where theta_t is constant
@@ -71,8 +71,10 @@ mod tests_ho_lee {
 
         // X_0 = 10.0
         // T = 1.0
-        let config = StochasticProcessConfig::new(10.0, 0.0, 1.0, 125, 1000, false);
-        let output = hl.euler_maruyama(&config);
+        let config = StochasticProcessConfig::new(
+            10.0, 0.0, 1.0, 125, StochasticScheme::EulerMaruyama, 1000, false, None
+        );
+        let output = hl.monte_carlo(&config);
 
         // Test the distribution of the final values.
         let X_T: Vec<f64> = output

--- a/crates/RustQuant_stochastics/src/ho_lee.rs
+++ b/crates/RustQuant_stochastics/src/ho_lee.rs
@@ -74,7 +74,7 @@ mod tests_ho_lee {
         let config = StochasticProcessConfig::new(
             10.0, 0.0, 1.0, 125, StochasticScheme::EulerMaruyama, 1000, false, None
         );
-        let output = hl.monte_carlo(&config);
+        let output = hl.generate(&config);
 
         // Test the distribution of the final values.
         let X_T: Vec<f64> = output

--- a/crates/RustQuant_stochastics/src/hull_white.rs
+++ b/crates/RustQuant_stochastics/src/hull_white.rs
@@ -62,7 +62,7 @@ impl StochasticProcess for HullWhite {
 #[cfg(test)]
 mod tests_hull_white {
     use super::*;
-    use crate::StochasticProcessConfig;
+    use crate::{StochasticProcessConfig, StochasticScheme};
     use RustQuant_math::*;
     use RustQuant_utils::assert_approx_equal;
 
@@ -77,9 +77,11 @@ mod tests_hull_white {
         let sigma = 2.0;
 
         let hw = HullWhite::new(alpha, sigma, theta);
-        let config = StochasticProcessConfig::new(10.0, 0.0, 1.0, 150, 1000, false);
+        let config = StochasticProcessConfig::new(
+            10.0, 0.0, 1.0, 150, StochasticScheme::EulerMaruyama, 1000, false, None
+        );
 
-        let output = hw.euler_maruyama(&config);
+        let output = hw.monte_carlo(&config);
 
         // Test the distribution of the final values.
         let X_T: Vec<f64> = output

--- a/crates/RustQuant_stochastics/src/hull_white.rs
+++ b/crates/RustQuant_stochastics/src/hull_white.rs
@@ -81,7 +81,7 @@ mod tests_hull_white {
             10.0, 0.0, 1.0, 150, StochasticScheme::EulerMaruyama, 1000, false, None
         );
 
-        let output = hw.monte_carlo(&config);
+        let output = hw.generate(&config);
 
         // Test the distribution of the final values.
         let X_T: Vec<f64> = output

--- a/crates/RustQuant_stochastics/src/lib.rs
+++ b/crates/RustQuant_stochastics/src/lib.rs
@@ -36,7 +36,7 @@
 //! // Generate path using Euler-Maruyama scheme.
 //! // Parameters: x_0, t_0, t_n, n, sims, parallel.
 //! let config = StochasticProcessConfig::new(10., 0., 0.5, 10, StochasticScheme::EulerMaruyama, 1, false, None);
-//! let output = (&gbm).monte_carlo(&config);
+//! let output = (&gbm).generate(&config);
 //!
 //! println!("GBM = {:?}", output.paths);
 //! ```
@@ -129,5 +129,5 @@ pub use curve_model::*;
 pub mod fractional_process;
 pub use fractional_process::*;
 
-/// Private monte carlo module.
-mod monte_carlo;
+/// Private stochastic process simulation module.
+mod simulation;

--- a/crates/RustQuant_stochastics/src/lib.rs
+++ b/crates/RustQuant_stochastics/src/lib.rs
@@ -35,8 +35,8 @@
 //!
 //! // Generate path using Euler-Maruyama scheme.
 //! // Parameters: x_0, t_0, t_n, n, sims, parallel.
-//! let config = StochasticProcessConfig::new(10., 0., 0.5, 10, 1, false);
-//! let output = (&gbm).euler_maruyama(&config);
+//! let config = StochasticProcessConfig::new(10., 0., 0.5, 10, StochasticScheme::EulerMaruyama, 1, false, None);
+//! let output = (&gbm).monte_carlo(&config);
 //!
 //! println!("GBM = {:?}", output.paths);
 //! ```

--- a/crates/RustQuant_stochastics/src/lib.rs
+++ b/crates/RustQuant_stochastics/src/lib.rs
@@ -124,3 +124,10 @@ pub use nelson_siegel_svensson::*;
 /// Curve model trait.
 pub mod curve_model;
 pub use curve_model::*;
+
+/// Fractional Brownian Motion.
+pub mod fractional_process;
+pub use fractional_process::*;
+
+/// Private monte carlo module.
+mod monte_carlo;

--- a/crates/RustQuant_stochastics/src/merton_jump_diffusion.rs
+++ b/crates/RustQuant_stochastics/src/merton_jump_diffusion.rs
@@ -74,7 +74,7 @@ impl StochasticProcess for MertonJumpDiffusion {
         vec![self.mu.0(0.0), self.sigma.0(0.0), self.lambda.0(0.0)]
     }
 
-    fn euler_maruyama(&self, config: &StochasticProcessConfig) -> Trajectories {
+    fn monte_carlo(&self, config: &StochasticProcessConfig) -> Trajectories {
         let (x_0, t_0, t_n, n_steps, m_paths, parallel) = config.unpack();
 
         assert!(t_0 < t_n);
@@ -127,15 +127,17 @@ impl StochasticProcess for MertonJumpDiffusion {
 #[cfg(test)]
 mod tests_gbm_bridge {
     use super::*;
-    use crate::StochasticProcessConfig;
+    use crate::{StochasticProcessConfig, StochasticScheme};
     use RustQuant_math::*;
     use RustQuant_utils::assert_approx_equal;
 
     #[test]
     fn test_geometric_brownian_motion_bridge() {
         let mjd = MertonJumpDiffusion::new(0.05, 0.9, 1.0, 0.0, 0.3);
-        let config = StochasticProcessConfig::new(10.0, 0.0, 0.5, 125, 10000, false);
-        let output = mjd.euler_maruyama(&config);
+        let config = StochasticProcessConfig::new(
+            10.0, 0.0, 0.5, 125, StochasticScheme::EulerMaruyama, 10000, false, None
+        );
+        let output = mjd.monte_carlo(&config);
 
         // Test the distribution of the final values.
         let X_T: Vec<f64> = output

--- a/crates/RustQuant_stochastics/src/merton_jump_diffusion.rs
+++ b/crates/RustQuant_stochastics/src/merton_jump_diffusion.rs
@@ -9,7 +9,7 @@
 
 use crate::model_parameter::ModelParameter;
 use crate::process::{StochasticProcess, StochasticProcessConfig};
-use crate::monte_carlo::run_monte_carlo;
+use crate::simulation::simulate_stochatic_process;
 use RustQuant_math::Gaussian;
 use RustQuant_math::Distribution as LocalDistribution;
 
@@ -72,8 +72,8 @@ impl StochasticProcess for MertonJumpDiffusion {
         vec![self.mu.0(0.0), self.sigma.0(0.0), self.lambda.0(0.0)]
     }
 
-    fn monte_carlo(&self, config: &StochasticProcessConfig) -> crate::process::Trajectories {
-        run_monte_carlo(self, config, Some(self.lambda.0(0.0)), None)
+    fn generate(&self, config: &StochasticProcessConfig) -> crate::process::Trajectories {
+        simulate_stochatic_process(self, config, Some(self.lambda.0(0.0)), None)
     }
 }
 
@@ -90,7 +90,7 @@ mod tests_gbm_bridge {
         let config = StochasticProcessConfig::new(
             10.0, 0.0, 0.5, 125, StochasticScheme::EulerMaruyama, 10000, false, None
         );
-        let output = mjd.monte_carlo(&config);
+        let output = mjd.generate(&config);
 
         // Test the distribution of the final values.
         let X_T: Vec<f64> = output

--- a/crates/RustQuant_stochastics/src/monte_carlo.rs
+++ b/crates/RustQuant_stochastics/src/monte_carlo.rs
@@ -1,0 +1,222 @@
+use rayon::prelude::*;
+use rand::prelude::Distribution;
+use rand::{rngs::StdRng, SeedableRng};
+use crate::process::{StochasticProcess, Trajectories, StochasticProcessConfig, StochasticScheme};
+use RustQuant_math::{Distribution as LocalDistribution, Poisson};
+
+
+enum NoiseGenerator {
+    Dynamic(StdRng),
+    Fractional((fn(f64, usize, f64, Option<u64>) -> Vec<f64>, f64)),
+}
+
+pub(crate) fn run_monte_carlo<T: StochasticProcess>(
+        stochastic_process: &T,
+        config: &StochasticProcessConfig,
+        jump_config: Option<f64>,
+        fractional_config: Option<(fn(f64, usize, f64, Option<u64>) -> Vec<f64>, f64)>
+    ) -> Trajectories {
+    assert!(config.t_0 < config.t_n);
+
+    let dt: f64 = (config.t_n - config.t_0) / (config.n_steps as f64);
+
+    let times: Vec<f64> = (0..=config.n_steps)
+        .map(|t| config.t_0 + dt * (t as f64))
+        .collect();
+
+    let times_ref: &[f64] = &times;
+    let normal_dist: rand_distr::Normal<f64> = rand_distr::Normal::new(0.0, 1.0).unwrap();
+    let diffusion_scale: f64 = dt.sqrt();
+
+    let jumps: &[f64] = match jump_config {
+        Some(lambda) => {
+            &Poisson::new(lambda * dt).sample(config.n_steps).unwrap()
+        }
+        None => &vec![],
+    };
+
+    let scheme = match config.scheme {
+        StochasticScheme::EulerMaruyama => Box::new({
+            |path: &mut Vec<f64>, mut noise_gen: NoiseGenerator| {
+
+                let fraction_noise: Vec<f64> = match noise_gen {
+                    NoiseGenerator::Fractional(fractional_config) => {
+                        fractional_config.0(fractional_config.1, config.n_steps, config.t_n, config.seed)
+                    },
+                    NoiseGenerator::Dynamic(_) => vec![],
+                };
+
+                for t in 0..config.n_steps {                    
+                    path.push(
+                        path[t]
+                        + stochastic_process.drift(path[t], times_ref[t]) * dt
+                        + stochastic_process.diffusion(path[t], times_ref[t]) * diffusion_scale * match noise_gen {
+                            NoiseGenerator::Dynamic(ref mut rng) => normal_dist.sample(rng),
+                            NoiseGenerator::Fractional(_) => fraction_noise[t],
+                        } + match !jumps.is_empty() {
+                            true => calculate_jump(stochastic_process, path[t], times_ref[t], jumps[t]),
+                            false => 0.0,
+                        }
+                    );
+                }
+            }
+        }) as Box<dyn Fn(&mut Vec<f64>, NoiseGenerator) + Send + Sync>,
+        StochasticScheme::Milstein => Box::new({
+            |path: &mut Vec<f64>, mut noise_gen: NoiseGenerator| {
+
+                let fraction_noise: Vec<f64> = match noise_gen {
+                    NoiseGenerator::Fractional(fractional_config) => {
+                        fractional_config.0(fractional_config.1, config.n_steps, config.t_n, config.seed)
+                    },
+                    NoiseGenerator::Dynamic(_) => vec![],
+                };
+
+                let mut dw: f64;
+                for t in 0..config.n_steps {
+                    dw = match noise_gen {
+                        NoiseGenerator::Dynamic(ref mut rng) => normal_dist.sample(rng),
+                        NoiseGenerator::Fractional(_) => fraction_noise[t],
+                    };
+                    path.push(
+                        path[t]
+                        + stochastic_process.drift(path[t], times_ref[t]) * dt
+                        + stochastic_process.diffusion(path[t], times_ref[t]) * dw
+                        + 0.5
+                        * (stochastic_process.diffusion(path[t], times_ref[t])
+                        * ((stochastic_process.diffusion(path[t] + 1e-5, times_ref[t])
+                                    - stochastic_process.diffusion(path[t] - 1e-5, times_ref[t]))
+                                    / 2.0
+                                    * 1e-5)
+                        * ((dw * dw) - dt))
+                        + match !jumps.is_empty() {
+                            true => calculate_jump(stochastic_process, path[t], times_ref[t], jumps[t]),
+                            false => 0.0,
+                        }
+                    );
+                }
+            }
+        }) as Box<dyn Fn(&mut Vec<f64>, NoiseGenerator) + Send + Sync>,
+        StochasticScheme::StrangSplitting => Box::new({
+            |path: &mut Vec<f64>, mut noise_gen: NoiseGenerator| {
+
+
+                let fraction_noise: Vec<f64> = match noise_gen {
+                    NoiseGenerator::Fractional(fractional_config) => {
+                        fractional_config.0(fractional_config.1, config.n_steps, config.t_n, config.seed)
+                    },
+                    NoiseGenerator::Dynamic(_) => vec![],
+                };
+
+                for t in 0..config.n_steps {
+                    path.push(
+                        path[t]
+                        + 0.5 * stochastic_process.drift(path[t], times_ref[t]) * dt
+                        + stochastic_process.diffusion(
+                            path[t] + 0.5 * stochastic_process.drift(path[t], times[t]) * dt,
+                            times[t] + 0.5 * dt,
+                        ) * match noise_gen {
+                            NoiseGenerator::Dynamic(ref mut rng) => normal_dist.sample(rng),
+                            NoiseGenerator::Fractional(_) => fraction_noise[t],
+                        } + 0.5 * stochastic_process.drift(path[t], times_ref[t]) * dt
+                        + match !jumps.is_empty() {
+                            true => calculate_jump(stochastic_process, path[t], times_ref[t], jumps[t]),
+                            false => 0.0,
+                        }
+                    );
+                }
+            }
+        }) as Box<dyn Fn(&mut Vec<f64>, NoiseGenerator) + Send + Sync>,
+    };
+
+    let mut paths: Vec<Vec<f64>> = vec![vec![config.x_0]; config.m_paths];
+
+    let base_seed: u64 = config.seed.unwrap_or_else(rand::random);
+    if config.parallel {
+        paths.par_iter_mut().enumerate().for_each(|(i, path)| {
+            let noise_gen = match fractional_config {
+                Some(fractional_config) => NoiseGenerator::Fractional(fractional_config),
+                None => NoiseGenerator::Dynamic(StdRng::seed_from_u64(base_seed.wrapping_add(i as u64))),
+            };
+            scheme(path, noise_gen);
+        });
+    } else {
+        paths.iter_mut().enumerate().for_each(|(i, path)| {
+            let noise_gen = match fractional_config {
+                Some(fractional_config) => NoiseGenerator::Fractional(fractional_config),
+                None => NoiseGenerator::Dynamic(StdRng::seed_from_u64(base_seed.wrapping_add(i as u64))),
+            };
+            scheme(path, noise_gen);
+        });
+    }
+
+    Trajectories {
+        times: times.to_vec(),
+        paths,
+    }
+}
+
+fn calculate_jump<T: StochasticProcess>(
+    stochastic_process: &T,
+    x: f64,
+    time_ref: f64,
+    jump: f64,
+) -> f64 {
+    match stochastic_process.jump(x, time_ref) {
+        Some(jump_size) => {
+            if jump > 0.0 {
+                jump_size
+            } else {
+                0.0
+            }
+        },
+        None => 0.0,
+    }
+}
+
+#[cfg(test)]
+mod test_process {
+    use crate::geometric_brownian_motion::GeometricBrownianMotion;
+    use crate::{StochasticScheme, StochasticProcessConfig, StochasticProcess};
+    use std::time::Instant;
+    use super::run_monte_carlo;
+
+    #[test]
+    fn test_run_monte_carlo() {
+
+        struct CustomProcess {
+            pub mu: f64,
+        
+            pub sigma: f64,
+        }
+        
+        impl StochasticProcess for CustomProcess {
+
+            fn drift(&self, x: f64, _t: f64) -> f64 {
+                self.mu * x
+            }
+        
+            fn diffusion(&self, x: f64, _t: f64) -> f64 {
+                self.sigma * x
+            }
+        
+            fn jump(&self, _x: f64, _t: f64) -> Option<f64> {
+                Some(1.0)
+            }
+        }
+        
+        let config = StochasticProcessConfig::new(
+            10.0,
+            0.0,
+            1.0,
+            10,
+            StochasticScheme::EulerMaruyama,
+            3,
+            false,
+            Some(9999),
+        );
+
+        let stochastic_process = CustomProcess { mu: 0.1, sigma: 0.2 };
+
+        run_monte_carlo(&stochastic_process, &config, Some(1.0), None);
+    }
+}

--- a/crates/RustQuant_stochastics/src/monte_carlo.rs
+++ b/crates/RustQuant_stochastics/src/monte_carlo.rs
@@ -175,9 +175,7 @@ fn calculate_jump<T: StochasticProcess>(
 
 #[cfg(test)]
 mod test_process {
-    use crate::geometric_brownian_motion::GeometricBrownianMotion;
     use crate::{StochasticScheme, StochasticProcessConfig, StochasticProcess};
-    use std::time::Instant;
     use super::run_monte_carlo;
 
     #[test]

--- a/crates/RustQuant_stochastics/src/ornstein_uhlenbeck.rs
+++ b/crates/RustQuant_stochastics/src/ornstein_uhlenbeck.rs
@@ -64,7 +64,7 @@ impl StochasticProcess for OrnsteinUhlenbeck {
 #[cfg(test)]
 mod tests_ornstein_uhlenbeck {
     use super::*;
-    use crate::StochasticProcessConfig;
+    use crate::{StochasticProcessConfig, StochasticScheme};
     use RustQuant_math::*;
     use RustQuant_utils::assert_approx_equal;
 
@@ -72,8 +72,10 @@ mod tests_ornstein_uhlenbeck {
     fn test_ornstein_uhlenbeck() {
         let ou = OrnsteinUhlenbeck::new(0.15, 0.45, 0.01);
 
-        let config = StochasticProcessConfig::new(10.0, 0.0, 0.5, 100, 100, false);
-        let output = ou.euler_maruyama(&config);
+        let config = StochasticProcessConfig::new(
+            10.0, 0.0, 0.5, 100, StochasticScheme::EulerMaruyama,100, false, None
+        );
+        let output = ou.monte_carlo(&config);
 
         // Test the distribution of the final values.
         let X_T: Vec<f64> = output

--- a/crates/RustQuant_stochastics/src/ornstein_uhlenbeck.rs
+++ b/crates/RustQuant_stochastics/src/ornstein_uhlenbeck.rs
@@ -75,7 +75,7 @@ mod tests_ornstein_uhlenbeck {
         let config = StochasticProcessConfig::new(
             10.0, 0.0, 0.5, 100, StochasticScheme::EulerMaruyama,100, false, None
         );
-        let output = ou.monte_carlo(&config);
+        let output = ou.generate(&config);
 
         // Test the distribution of the final values.
         let X_T: Vec<f64> = output

--- a/crates/RustQuant_stochastics/src/process.rs
+++ b/crates/RustQuant_stochastics/src/process.rs
@@ -17,7 +17,7 @@
 use rand::prelude::Distribution;
 use rayon::prelude::*;
 
-use crate::monte_carlo::run_monte_carlo;
+use crate::simulation::simulate_stochatic_process;
 
 /// Struct to contain the time points and path values of the process.
 pub struct Trajectories {
@@ -221,12 +221,12 @@ pub trait StochasticProcess: Sync {
         vec![]
     }
 
-    /// Runs a Monte Carlo simulation for a stochastic process.
-    fn monte_carlo(&self, config: &StochasticProcessConfig) -> Trajectories
+    /// Simulate the stochastic process.
+    fn generate(&self, config: &StochasticProcessConfig) -> Trajectories
     where
         Self: Sized,
     {
-        run_monte_carlo(self, config, None, None)
+        simulate_stochatic_process(self, config, None, None)
     }
 }
 
@@ -251,13 +251,13 @@ mod test_process {
         );
 
         let start = Instant::now();
-        gbm.monte_carlo(&config);
+        gbm.generate(&config);
         let serial = start.elapsed();
 
         println!("Serial: \t {:?}", serial);
 
         let start = Instant::now();
-        gbm.monte_carlo(&config);
+        gbm.generate(&config);
         let parallel = start.elapsed();
 
         println!("Parallel: \t {:?}", parallel);
@@ -282,13 +282,13 @@ mod test_process {
         );
 
         let start = Instant::now();
-        gbm.monte_carlo(&config);
+        gbm.generate(&config);
         let serial = start.elapsed();
 
         println!("Serial: \t {:?}", serial);
 
         let start = Instant::now();
-        gbm.monte_carlo(&config);
+        gbm.generate(&config);
         let parallel = start.elapsed();
 
         println!("Parallel: \t {:?}", parallel);
@@ -313,13 +313,13 @@ mod test_process {
         );
 
         let start = Instant::now();
-        gbm.monte_carlo(&config);
+        gbm.generate(&config);
         let serial = start.elapsed();
 
         println!("Serial: \t {:?}", serial);
 
         let start = Instant::now();
-        gbm.monte_carlo(&config);
+        gbm.generate(&config);
         let parallel = start.elapsed();
 
         println!("Parallel: \t {:?}", parallel);

--- a/crates/RustQuant_stochastics/src/process.rs
+++ b/crates/RustQuant_stochastics/src/process.rs
@@ -17,6 +17,8 @@
 use rand::prelude::Distribution;
 use rand::{rngs::StdRng, SeedableRng};
 use rayon::prelude::*;
+use time::format_description::modifier::UnixTimestamp;
+use std::sync::Arc;
 // use statrs::distribution::Normal;
 
 /// Struct to contain the time points and path values of the process.
@@ -26,6 +28,17 @@ pub struct Trajectories {
 
     /// Vector of process trajectories.
     pub paths: Vec<Vec<f64>>,
+}
+
+/// Enum for Stochastic Methods
+#[derive(Clone, Copy)]
+pub enum StochasticScheme {
+    /// Euler-Maruyama
+    EulerMaruyama,
+    /// Milstein's Method
+    Milstein,
+    /// Strang Splitting
+    StrangSplitting,
 }
 
 /// Trait to implement stochastic volatility processes.
@@ -123,11 +136,17 @@ pub struct StochasticProcessConfig {
     /// Number of time steps between `t_0` and `t_n`.
     pub n_steps: usize,
 
+    /// Numerical method
+    pub scheme: StochasticScheme,
+
     /// How many process trajectories to simulate.
     pub m_paths: usize,
 
     /// Run in parallel or not (recommended for > 1000 paths).
     pub parallel: bool,
+
+    /// Optional seed argument to initialize random number generator
+    pub seed: Option<u64>,
 }
 
 impl StochasticProcessConfig {
@@ -137,28 +156,167 @@ impl StochasticProcessConfig {
         t_0: f64,
         t_n: f64,
         n_steps: usize,
+        scheme: StochasticScheme,
         m_paths: usize,
         parallel: bool,
+        seed: Option<u64>,
     ) -> Self {
         Self {
             x_0,
             t_0,
             t_n,
+            scheme,
             n_steps,
             m_paths,
             parallel,
+            seed,
         }
     }
 
-    pub(crate) fn unpack(&self) -> (f64, f64, f64, usize, usize, bool) {
+    pub(crate) fn unpack(
+        &self,
+    ) -> (
+        f64,
+        f64,
+        f64,
+        usize,
+        StochasticScheme,
+        usize,
+        bool,
+        Option<u64>,
+    ) {
         (
             self.x_0,
             self.t_0,
             self.t_n,
             self.n_steps,
+            self.scheme,
             self.m_paths,
             self.parallel,
+            self.seed,
         )
+    }
+
+    fn unpack_for_scheme(&self, dt: f64, config: &StochasticProcessConfig) -> (f64, usize, Vec<f64>) {
+        let times: Vec<f64> = (0..=config.n_steps)
+        .map(|t| config.t_0 + dt * (t as f64))
+        .collect();
+
+        (self.x_0, self.n_steps, times)
+    }
+}
+
+// fn select_scheme<'a, T: StochasticProcess>(
+//     obj: &'a T,
+//     noise_path: Vec<f64>,
+//     dt: f64,
+//     config: &'a StochasticProcessConfig,
+// ) -> Box<dyn Fn(&mut Vec<f64>) + Send + Sync + 'a> {
+
+// fn noise()
+
+fn select_scheme<'a, T: StochasticProcess>(
+        obj: &'a T,
+        noise_path: Option<Vec<f64>>,
+        dt: f64,
+        config: &'a StochasticProcessConfig,
+    ) -> Trajectories {
+    assert!(config.t_0 < config.t_n);
+
+    // let times: &[f64] = &(0..=config.n_steps)
+    //     .map(|t| config.t_0 + dt * (t as f64))
+    //     .collect::<Vec<f64>>();
+    // let mut paths: Vec<Vec<f64>> = vec![vec![config.x_0; config.n_steps + 1]; config.m_paths];
+
+    let times: Vec<f64> = (0..=config.n_steps)
+        .map(|t| config.t_0 + dt * (t as f64))
+        .collect();
+
+    let scheme = match config.scheme {
+        StochasticScheme::EulerMaruyama => Box::new({
+            // let obj = obj;
+            // let times = times.clone();
+            move |path: &mut Vec<f64>| {
+                // let (x_0, n_steps, times) = config.unpack_for_scheme(dt.clone(), config);
+                path.clear();
+                path.push(config.x_0);
+                let mut dw: f64 = 1.0;
+
+                for t in 0..config.n_steps {
+                    // dw = diffusion_scale * normal_dist.sample(&mut rng);
+                    path.push(
+                        path[t]
+                            + obj.drift(path[t], times[t]) * dt
+                            + obj.diffusion(path[t], times[t]) * dw,
+                    );
+                }
+            }
+        }) as Box<dyn Fn(&mut Vec<f64>) + Send + Sync>,
+        StochasticScheme::Milstein => Box::new({
+            move |path: &mut Vec<f64>| {
+                // let (x_0, n_steps, times) = config.unpack_for_scheme(dt, config);
+                path.clear();
+                path.push(config.x_0);
+                let mut dw: f64 = 1.0;
+                for t in 0..config.n_steps {
+                    // dw = diffusion_scale * normal_dist.sample(&mut rng);
+                    path.push(
+                        path[t]
+                            + obj.drift(path[t], times[t]) * dt
+                            + obj.diffusion(path[t], times[t]) * dw
+                            + 0.5
+                                * (obj.diffusion(path[t], times[t])
+                                    * ((obj.diffusion(path[t] + 1e-5, times[t])
+                                        - obj.diffusion(path[t] - 1e-5, times[t]))
+                                        / 2.0
+                                        * 1e-5)
+                                    * ((dw * dw) - dt)),
+                    );
+                }
+            }
+        }) as Box<dyn Fn(&mut Vec<f64>) + Send + Sync>,
+        StochasticScheme::StrangSplitting => Box::new({
+            move |path: &mut Vec<f64>| {
+                // let (x_0, n_steps, times) = config.unpack_for_scheme(dt, config);
+                path.clear();
+                path.push(config.x_0);
+                let mut dw: f64 = 1.0;
+
+                for t in 0..config.n_steps {
+                    // dw = diffusion_scale * normal_dist.sample(&mut rng);
+                    path.push(
+                        path[t]
+                            + 0.5 * obj.drift(path[t], times[t]) * dt
+                            + obj.diffusion(
+                                path[t] + 0.5 * obj.drift(path[t], times[t]) * dt,
+                                times[t] + 0.5 * dt,
+                            ) * dw
+                            + 0.5 * obj.drift(path[t], times[t]) * dt,
+                    )
+                }
+            }
+        }) as Box<dyn Fn(&mut Vec<f64>) + Send + Sync>,
+    };
+
+    let mut paths: Vec<Vec<f64>> = vec![vec![config.x_0; config.n_steps + 1]; config.m_paths];
+
+    // fractional passes in only a clsure into for_each
+    // get non-fractional in the same state
+    if config.parallel {
+        paths.par_iter_mut().enumerate().for_each(|(i, path)| {
+            // let rng: StdRng = StdRng::seed_from_u64(base_seed.wrapping_add(i as u64));
+            scheme(path);
+        });
+    } else {
+        paths.iter_mut().enumerate().for_each(|(i, path)| {
+            // let rng: StdRng = StdRng::seed_from_u64(base_seed.wrapping_add(i as u64));
+            scheme(path);
+        });
+    }
+
+    Trajectories {
+        times: times.to_vec(),
+        paths: paths,
     }
 }
 
@@ -179,126 +337,108 @@ pub trait StochasticProcess: Sync {
         vec![]
     }
 
-    /// Euler-Maruyama discretisation scheme.
-    ///
-    /// # Arguments:
-    /// * `x_0` - The process' initial value at `t_0`.
-    /// * `t_0` - The initial time point.
-    /// * `t_n` - The terminal time point.
-    /// * `n_steps` - The number of time steps between `t_0` and `t_n`.
-    /// * `m_paths` - How many process trajectories to simulate.
-    /// * `parallel` - Run in parallel or not (recommended for > 1000 paths).
-    fn euler_maruyama(&self, config: &StochasticProcessConfig) -> Trajectories {
-        let (x_0, t_0, t_n, n_steps, m_paths, parallel) = config.unpack();
-        assert!(t_0 < t_n);
+    /// Simulate via Monte-Carlo.
+    fn _monte_carlo(&self, config: &StochasticProcessConfig, noise_path: Vec<f64>) -> Trajectories {
+        // let p = times.as_sl;
+        // let times_slice: &[f64] = &times;
 
-        let dt: f64 = (t_n - t_0) / (n_steps as f64);
+        let dt: f64 = (config.t_n - config.t_0) / (config.n_steps as f64);
 
-        // Initialise empty paths and fill in the time points.
-        let mut paths = vec![vec![x_0; n_steps + 1]; m_paths];
-        let times: Vec<f64> = (0..=n_steps).map(|t| t_0 + dt * (t as f64)).collect();
+        // needs to be generalised
+        let base_seed: u64 = config.seed.unwrap_or_else(rand::random);
+        let normal_dist: rand_distr::Normal<f64> = rand_distr::Normal::new(0.0, 1.0).unwrap();
+        let diffusion_scale: f64 = dt.sqrt();
 
-        let path_generator = |path: &mut Vec<f64>| {
-            let mut rng = rand::thread_rng();
-            let scale = dt.sqrt();
-            let dW: Vec<f64> = rand_distr::Normal::new(0.0, 1.0)
-                .unwrap()
-                .sample_iter(&mut rng)
-                .take(n_steps)
-                .map(|z| z * scale)
-                .collect();
+        let noise_path: Vec<f64> = (0..config.n_steps)
+            .map(|t| {
+                let rng: StdRng = StdRng::seed_from_u64(base_seed.wrapping_add(t as u64));
+                diffusion_scale * normal_dist.sample(&mut rng)
+            })
+            .collect();
 
-            for t in 0..n_steps {
-                path[t + 1] = path[t]
-                    + self.drift(path[t], times[t]) * dt
-                    + self.diffusion(path[t], times[t]) * dW[t];
-            }
-        };
+        // Return scheme here
 
-        if parallel {
-            paths.par_iter_mut().for_each(path_generator);
+        if config.parallel {
+            paths.par_iter_mut().enumerate().for_each(|(i, path)| {
+                let rng: StdRng = StdRng::seed_from_u64(base_seed.wrapping_add(i as u64));
+                scheme(path);
+            });
         } else {
-            paths.iter_mut().for_each(path_generator);
+            paths.iter_mut().enumerate().for_each(|(i, path)| {
+                let rng: StdRng = StdRng::seed_from_u64(base_seed.wrapping_add(i as u64));
+                scheme(path);
+            });
         }
 
-        Trajectories { times, paths }
-    }
-
-    /// Euler-Maruyama discretisation scheme with a choice of random seed.
-    ///
-    /// # Arguments:
-    /// * `x_0` - The process' initial value at `t_0`.
-    /// * `t_0` - The initial time point.
-    /// * `t_n` - The terminal time point.
-    /// * `n_steps` - The number of time steps between `t_0` and `t_n`.
-    /// * `m_paths` - How many process trajectories to simulate.
-    /// * `parallel` - Run in parallel or not (recommended for > 1000 paths).
-    /// * `seed` - The seed for the random number generator.
-    fn seedable_euler_maruyama(
-        &self,
-        x_0: f64,
-        t_0: f64,
-        t_n: f64,
-        n_steps: usize,
-        m_paths: usize,
-        parallel: bool,
-        seed: u64,
-    ) -> Trajectories {
-        assert!(t_0 < t_n);
-
-        let dt: f64 = (t_n - t_0) / (n_steps as f64);
-
-        // Initialise empty paths and fill in the time points.
-        let mut paths = vec![vec![x_0; n_steps + 1]; m_paths];
-        let times: Vec<f64> = (0..=n_steps).map(|t| t_0 + dt * (t as f64)).collect();
-
-        let path_generator = |path: &mut Vec<f64>| {
-            let mut rng = StdRng::seed_from_u64(seed);
-            let scale = dt.sqrt();
-            let dW: Vec<f64> = rand_distr::Normal::new(0.0, 1.0)
-                .unwrap()
-                .sample_iter(&mut rng)
-                .take(n_steps)
-                .map(|z| z * scale)
-                .collect();
-
-            for t in 0..n_steps {
-                path[t + 1] = path[t]
-                    + self.drift(path[t], times[t]) * dt
-                    + self.diffusion(path[t], times[t]) * dW[t];
-            }
-        };
-
-        if parallel {
-            paths.par_iter_mut().for_each(path_generator);
-        } else {
-            paths.iter_mut().for_each(path_generator);
+        Trajectories {
+            times: times.to_vec(),
+            paths: paths,
         }
-
-        Trajectories { times, paths }
     }
+}
+
+pub trait MonteCarlo: StochasticProcess {
+
+    fn monte_carlo(&self, config: StochasticProcessConfig)
+    where
+        Self: Sized,
+    {
+        let dt: f64 = (config.t_n - config.t_0) / (config.n_steps as f64);
+
+        let base_seed: u64 = config.seed.unwrap_or_else(rand::random);
+        let normal_dist: rand_distr::Normal<f64> = rand_distr::Normal::new(0.0, 1.0).unwrap();
+        let diffusion_scale: f64 = dt.sqrt();
+
+        let noise_path: Vec<f64> = (0..config.n_steps)
+        .map(|t| {
+            let mut rng: StdRng = StdRng::seed_from_u64(base_seed.wrapping_add(t as u64));
+            diffusion_scale * normal_dist.sample(&mut rng)
+        })
+        .collect();
+
+        let dt: f64 = (config.t_n - config.t_0) / (config.n_steps as f64);
+        select_scheme(self, noise_path, dt, &config);
+    }
+
+}
+
+pub trait FractionalMonteCarlo: StochasticProcess {
+
+    fn monte_carlo(config: StochasticProcessConfig) {
+        
+    }
+
 }
 
 #[cfg(test)]
 mod test_process {
     use crate::geometric_brownian_motion::GeometricBrownianMotion;
     use crate::process::StochasticProcess;
-    use crate::StochasticProcessConfig;
+    use crate::{StochasticProcessConfig, StochasticScheme};
     use std::time::Instant;
 
     #[test]
     fn test_euler_maruyama() {
         let gbm = GeometricBrownianMotion::new(0.05, 0.9);
-        let config = StochasticProcessConfig::new(10.0, 0.0, 1.0, 125, 10000, false);
+        let config = StochasticProcessConfig::new(
+            10.0,
+            0.0,
+            1.0,
+            10,
+            StochasticScheme::EulerMaruyama,
+            3,
+            false,
+            Some(1337),
+        );
 
         let start = Instant::now();
-        gbm.euler_maruyama(&config);
+        gbm.monte_carlo(&config);
         let serial = start.elapsed();
 
         println!("Serial: \t {:?}", serial);
 
         let start = Instant::now();
-        gbm.euler_maruyama(&config);
+        gbm.monte_carlo(&config);
         let parallel = start.elapsed();
 
         println!("Parallel: \t {:?}", parallel);
@@ -309,27 +449,63 @@ mod test_process {
     }
 
     #[test]
-    fn test_seedable_maruyama() {
+    fn test_milstein() {
         let gbm = GeometricBrownianMotion::new(0.05, 0.9);
+        let config = StochasticProcessConfig::new(
+            10.0,
+            0.0,
+            1.0,
+            10,
+            StochasticScheme::Milstein,
+            3,
+            false,
+            Some(1337),
+        );
 
-        let output_first_seed =
-            gbm.seedable_euler_maruyama(10.0, 0.0, 1.0, 125, 10000, true, 123456789);
-        println!("First seed: \t {:?}", output_first_seed.paths[0][125]);
+        let start = Instant::now();
+        gbm.monte_carlo(&config);
+        let serial = start.elapsed();
 
-        let output_same_seed =
-            gbm.seedable_euler_maruyama(10.0, 0.0, 1.0, 125, 10000, true, 123456789);
-        println!("Same seed: \t {:?}", output_same_seed.paths[0][125]);
+        println!("Serial: \t {:?}", serial);
 
-        // Check that using the same seed gives the same output.
-        assert_eq!(output_first_seed.paths, output_same_seed.paths);
+        let start = Instant::now();
+        gbm.monte_carlo(&config);
+        let parallel = start.elapsed();
 
-        let output_different_seed =
-            gbm.seedable_euler_maruyama(10.0, 0.0, 1.0, 125, 10000, true, 987654321);
-        println!("Different seed: {:?}", output_different_seed.paths[0][125]);
+        println!("Parallel: \t {:?}", parallel);
 
-        // Check that using a different seed gives a different output.
-        assert_ne!(output_first_seed.paths, output_different_seed.paths);
+        // Just checking that `parallel = true` actually works.
+        // To see the output of this "test", run:
+        // cargo test test_process -- --nocapture
+    }
 
+    #[test]
+    fn test_strang_splitter() {
+        let gbm = GeometricBrownianMotion::new(0.05, 0.9);
+        let config = StochasticProcessConfig::new(
+            10.0,
+            0.0,
+            1.0,
+            10,
+            StochasticScheme::StrangSplitting,
+            3,
+            false,
+            Some(1337),
+        );
+
+        let start = Instant::now();
+        gbm.monte_carlo(&config);
+        let serial = start.elapsed();
+
+        println!("Serial: \t {:?}", serial);
+
+        let start = Instant::now();
+        gbm.monte_carlo(&config);
+        let parallel = start.elapsed();
+
+        println!("Parallel: \t {:?}", parallel);
+
+        // Just checking that `parallel = true` actually works.
         // To see the output of this "test", run:
         // cargo test test_process -- --nocapture
     }

--- a/crates/RustQuant_stochastics/src/simulation.rs
+++ b/crates/RustQuant_stochastics/src/simulation.rs
@@ -1,3 +1,12 @@
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// RustQuant: A Rust library for quantitative finance tools.
+// Copyright (C) 2023 https://github.com/avhz
+// Dual licensed under Apache 2.0 and MIT.
+// See:
+//      - LICENSE-APACHE.md
+//      - LICENSE-MIT.md
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 use rayon::prelude::*;
 use rand::prelude::Distribution;
 use rand::{rngs::StdRng, SeedableRng};
@@ -10,7 +19,7 @@ enum NoiseGenerator {
     Fractional((fn(f64, usize, f64, Option<u64>) -> Vec<f64>, f64)),
 }
 
-pub(crate) fn run_monte_carlo<T: StochasticProcess>(
+pub(crate) fn simulate_stochatic_process<T: StochasticProcess>(
         stochastic_process: &T,
         config: &StochasticProcessConfig,
         jump_config: Option<f64>,
@@ -176,11 +185,10 @@ fn calculate_jump<T: StochasticProcess>(
 #[cfg(test)]
 mod test_process {
     use crate::{StochasticScheme, StochasticProcessConfig, StochasticProcess};
-    use super::run_monte_carlo;
+    use super::simulate_stochatic_process;
 
     #[test]
-    fn test_run_monte_carlo() {
-
+    fn test_run_simulate_stochastic_process() {
         struct CustomProcess {
             pub mu: f64,
         
@@ -215,6 +223,6 @@ mod test_process {
 
         let stochastic_process = CustomProcess { mu: 0.1, sigma: 0.2 };
 
-        run_monte_carlo(&stochastic_process, &config, Some(1.0), None);
+        simulate_stochatic_process(&stochastic_process, &config, Some(1.0), None);
     }
 }

--- a/examples/examples/custom_payoffs.rs
+++ b/examples/examples/custom_payoffs.rs
@@ -65,7 +65,7 @@ fn main() {
     let config = StochasticProcessConfig::new(
         INITIAL_VALUE, START_TIME, END_TIME, NUM_STEPS, StochasticScheme::EulerMaruyama, NUM_SIMS, PARALLEL, None
     );
-    let gbm_out = gbm.monte_carlo(&config);
+    let gbm_out = gbm.generate(&config);
 
     // Price the options. 
     println!("Up-and-out call: {}", barrier_option_payoff(&gbm_out.paths[0], 10.0, 12.0, OptionType::Call, BarrierType::UpAndOut));

--- a/examples/examples/custom_payoffs.rs
+++ b/examples/examples/custom_payoffs.rs
@@ -62,8 +62,10 @@ fn main() {
 
     // Generate path using Euler-Maruyama scheme.
     // Parameters: x_0, t_0, t_n, n, sims, parallel.
-    let config = StochasticProcessConfig::new(INITIAL_VALUE, START_TIME, END_TIME, NUM_STEPS, NUM_SIMS, PARALLEL);
-    let gbm_out = gbm.euler_maruyama(&config);
+    let config = StochasticProcessConfig::new(
+        INITIAL_VALUE, START_TIME, END_TIME, NUM_STEPS, StochasticScheme::EulerMaruyama, NUM_SIMS, PARALLEL, None
+    );
+    let gbm_out = gbm.monte_carlo(&config);
 
     // Price the options. 
     println!("Up-and-out call: {}", barrier_option_payoff(&gbm_out.paths[0], 10.0, 12.0, OptionType::Call, BarrierType::UpAndOut));

--- a/examples/examples/custom_process.rs
+++ b/examples/examples/custom_process.rs
@@ -45,7 +45,7 @@ fn main() {
     let config = StochasticProcessConfig::new(
         0.01, 0.0, 10.0, 500, StochasticScheme::EulerMaruyama, 1, false, None
     );
-    let output = custom_process.monte_carlo(&config);
+    let output = custom_process.generate(&config);
     plot_vector!(output.paths[0], "./images/ricker_wavelet_process.png");
 }
 

--- a/examples/examples/custom_process.rs
+++ b/examples/examples/custom_process.rs
@@ -22,9 +22,7 @@
 
 use std::f64::consts::PI;
 use RustQuant::{
-    math::Sequence,
-    stochastics::{process::StochasticProcess, StochasticProcessConfig},
-    utils::plot_vector,
+    math::Sequence, prelude::StochasticScheme, stochastics::{process::StochasticProcess, StochasticProcessConfig}, utils::plot_vector
 };
 
 fn main() {
@@ -44,8 +42,10 @@ fn main() {
     };
 
     // Generate a path and plot it.
-    let config = StochasticProcessConfig::new(0.01, 0.0, 10.0, 500, 1, false);
-    let output = custom_process.euler_maruyama(&config);
+    let config = StochasticProcessConfig::new(
+        0.01, 0.0, 10.0, 500, StochasticScheme::EulerMaruyama, 1, false, None
+    );
+    let output = custom_process.monte_carlo(&config);
     plot_vector!(output.paths[0], "./images/ricker_wavelet_process.png");
 }
 

--- a/examples/examples/monte_carlo_pricing.rs
+++ b/examples/examples/monte_carlo_pricing.rs
@@ -22,7 +22,16 @@ fn main() {
 
     // Create the stochastic process.
     let process = GeometricBrownianMotion::new(rate, volatility);
-    let config = StochasticProcessConfig::new(underlying, 0.0, time, 365, 100_000, true);
+    let config = StochasticProcessConfig::new(
+        underlying,
+        0.0,
+        time,
+        365,
+        StochasticScheme::EulerMaruyama,
+        100_000,
+        true,
+        None
+    );
 
     // Create the option contract.
     let direction = TypeFlag::Call;

--- a/examples/examples/stochastic_processes.rs
+++ b/examples/examples/stochastic_processes.rs
@@ -37,21 +37,23 @@ fn main() {
 
     // Generate path using Euler-Maruyama scheme.
     // Parameters: x_0, t_0, t_n, n, sims, parallel.
-    let config = StochasticProcessConfig::new(INITIAL_VALUE, START_TIME, END_TIME, NUM_STEPS, NUM_SIMS, PARALLEL);
+    let config = StochasticProcessConfig::new(
+        INITIAL_VALUE, START_TIME, END_TIME, NUM_STEPS, StochasticScheme::EulerMaruyama, NUM_SIMS, PARALLEL, None
+    );
 
-    let abm_out = abm.euler_maruyama(&config);
-    let bdt_out = bdt.euler_maruyama(&config);
-    let bm_out  = bm.euler_maruyama(&config);
-    let cir_out = cir.euler_maruyama(&config);
-    let ev_out  = ev.euler_maruyama(&config);
-    let gbm_out = gbm.euler_maruyama(&config);
-    let hl_out  = hl.euler_maruyama(&config);
-    let hw_out  = hw.euler_maruyama(&config);
-    let ou_out  = ou.euler_maruyama(&config);
-    let fbm_out = fbm.euler_maruyama(&config);
-    let mjd_out = mjd.euler_maruyama(&config);
-    let gbb_out = gbb.euler_maruyama(&config);
-    let cev_out = cev.euler_maruyama(&config);
+    let abm_out = abm.monte_carlo(&config);
+    let bdt_out = bdt.monte_carlo(&config);
+    let bm_out  = bm.monte_carlo(&config);
+    let cir_out = cir.monte_carlo(&config);
+    let ev_out  = ev.monte_carlo(&config);
+    let gbm_out = gbm.monte_carlo(&config);
+    let hl_out  = hl.monte_carlo(&config);
+    let hw_out  = hw.monte_carlo(&config);
+    let ou_out  = ou.monte_carlo(&config);
+    let fbm_out = fbm.monte_carlo(&config);
+    let mjd_out = mjd.monte_carlo(&config);
+    let gbb_out = gbb.monte_carlo(&config);
+    let cev_out = cev.monte_carlo(&config);
 
     // Plot the paths.
     plot_vector!(abm_out.paths[0].clone(), "./images/arithmetic_brownian_motion.png");

--- a/examples/examples/stochastic_processes.rs
+++ b/examples/examples/stochastic_processes.rs
@@ -41,19 +41,19 @@ fn main() {
         INITIAL_VALUE, START_TIME, END_TIME, NUM_STEPS, StochasticScheme::EulerMaruyama, NUM_SIMS, PARALLEL, None
     );
 
-    let abm_out = abm.monte_carlo(&config);
-    let bdt_out = bdt.monte_carlo(&config);
-    let bm_out  = bm.monte_carlo(&config);
-    let cir_out = cir.monte_carlo(&config);
-    let ev_out  = ev.monte_carlo(&config);
-    let gbm_out = gbm.monte_carlo(&config);
-    let hl_out  = hl.monte_carlo(&config);
-    let hw_out  = hw.monte_carlo(&config);
-    let ou_out  = ou.monte_carlo(&config);
-    let fbm_out = fbm.monte_carlo(&config);
-    let mjd_out = mjd.monte_carlo(&config);
-    let gbb_out = gbb.monte_carlo(&config);
-    let cev_out = cev.monte_carlo(&config);
+    let abm_out = abm.generate(&config);
+    let bdt_out = bdt.generate(&config);
+    let bm_out  = bm.generate(&config);
+    let cir_out = cir.generate(&config);
+    let ev_out  = ev.generate(&config);
+    let gbm_out = gbm.generate(&config);
+    let hl_out  = hl.generate(&config);
+    let hw_out  = hw.generate(&config);
+    let ou_out  = ou.generate(&config);
+    let fbm_out = fbm.generate(&config);
+    let mjd_out = mjd.generate(&config);
+    let gbb_out = gbb.generate(&config);
+    let cev_out = cev.generate(&config);
 
     // Plot the paths.
     plot_vector!(abm_out.paths[0].clone(), "./images/arithmetic_brownian_motion.png");


### PR DESCRIPTION
This Pull Request was created to address [issue 244](https://github.com/avhz/RustQuant/issues/244).

## Latest update

With these latest changes, the emphasis was on implementing the Monte-Carlo only once - so that we would only need to update the code in one place should we need to amend anything regarding the algorithm.

The following changes have been made:

- The `euler_maruyama()` method has been replaced with `monte_carlo()`
- The type of scheme (Euler-Maruyama, Milstein etc) can be chosen via the `StochasticScheme` enum as a parameter for `StochasticConfig`
- Monte-Carlo engine centralised in a private (public crate-wide) function `run_monte_carlo()` in `monte_carlo.rs`
- Jump diffusion processes have a simplified Monte-Carlo implementation (no need to reimplement the algorithm)
- The Monte-Carlo simulation for fractional stochastic processes has been centralised (no need to implement the same algorithm for each fractional process) and simplified
- Fractional stochastic process functionalities have been moved to the new `fractional_process.rs` module

Note: Jump/Fractional processes require a specific implementation of `run_monte_carlo()`. Although this works fine, there might be some issues when user's construct _custom_ jump/fractional processes (like in examples/examples/custom_process.rs) as default implementation will overlook jump/fractional properties. Added to future works section below.

### Benchmark tests

The following benchmark tests were run using the Euler-Maruyama scheme with the following configuration:
```
x_0 = 1.0
t_0 = 0.0
t_n = 1.0
n_steps = 1000
```

#### Standard Stochastic Process

`GeometricBrownianMotion` with 

```
mu = 1.0
sigma = 0.2
m_path = 100
```

| Branch | Run 1 | Run 2 | Run 3 | 
| ------------- | ------------- | ------------- | ------------- |
| `monte-carlo` | 72.253916ms | 77.608711ms | 70.91479ms |
| `main` | 110.545326ms | 90.941425ms | 101.169815ms |

This branch on average is 27% faster than `main` with Geometric Brownian Motion.

#### Jump Diffusion

`MertonJumpDiffusion` with 

```
mu = 1.0
sigma = 0.2
lambda = 1
m = 0.0
v = 0.1
m_path = 100
```

| Branch | Run 1 | Run 2 | Run 3 | 
| ------------- | ------------- | ------------- | ------------- |
| `monte-carlo` | 192.875529ms | 185.308736ms | 195.708128ms |
| `main` | 171.309267ms | 185.378698ms | 159.632454ms |

This branch is on average 11% slower than `main` with Merton Jump Diffusion.
We should consider whether generalisation of the Monte-Carlo method is worth this cost.
Of course, we can try to improve performance in a follow up (added to Future work section at the bottom). 

#### Fractional Process

`FractionalBrownianMotion` with

```
hurst = 0.1
method = FractionalProcessGeneratorMethod::Cholesky
m_path = 10
```

| Branch | Run 1 | Run 2 | Run 3 | 
| ------------- | ------------- | ------------- | ------------- |
| `monte-carlo` | 98.090812801s | 105.315690374s | 85.730874942s |
| `main` | 119.905169119s | 89.912333031s | 97.421714688s |

The performance on a Fraction Brownian motion process is roughly the same.

### Centralize Monte-Carlo functionality
Previously, the monte-carlo method needed to be implemented for each numerical method individually. Now there exists a private `monte_carlo()` function in the `process.rs` module which can be utilised for each numerical method defined in the `StochasticProcess` trait, removing the need for re-implementing the Monte-Carlo method every time.

### Consolidate seeded and "unseeded" numerical methods
The Euler Maruyama method had two implementations, one where a seed can be defined and another where the seed is "randomly" generated, `seedable_euler_maruyama` and `euler_maruyama` respectively.

A `seed: Option<u64>` parameter is introduced into `StochasticProcessConfig` to give the user the ability to fix outcomes, other can be entered as `None`, removing the need for two implementations of the same numerical methods.

## Milstein's scheme & Strang Splitting

The Milstein's scheme and Strang Splitting are numerical methods for SDEs that have been implemented in `process.rs` as part of this PR (and utilize `monte_carlo()` mentioned before). As such, `price_monte_carlo()` has been amended slightly to accomodate the new numerical methods.

Their methodologies are outlined below. 

Define the SDE

$$
dX = A(X, t)dt + B(X, t) dW_t
$$

where $W_t\sim N\left(0, t\right)$ is the Wiener process. We define $t_n = t_0 + n\Delta t$ where $\Delta t = \frac{t_N-t_0}{M}$.

### Milstein's Scheme

The Milstein scheme at time $t_n\in\left[t_0, t_N\right]$ is defined as

$$
X_{n+1} = X_n + A(X_n, t_n)\Delta t + B(X_n, t_n)\Delta W_t + \frac{1}{2}B(X_n, t_n)\frac{\partial}{\partial X}B\left(X_n, t_n\right)\left(\Delta W_n^2 - \Delta t\right)
$$

with the initial condition $X_0 = x_0$.

### Strang Splitter

The Strang Splitter method can be split into three steps:

1. Calculate the drift term over half a time step:

$$
X_{n+1/2} = X_n + \frac{1}{2}a\left(X_n, t\right)\Delta t
$$

2. Calculate the Diffusion term:

$$
X_{n+1/2} =X_{n+1/2} + b\left(X_{n+1/2}, t+\frac{1}{2}\Delta t\right)\Delta W_t
$$

3. Complete the full drift step:

$$
X_{n+1} = X_{n+1/2} + \frac{1}{2}a\left(X_{n+1/2}, t+\Delta t\right)\Delta t
$$

All appropriate unit tests have been added.

### Future work
- Generalise `monte_carlo()` to handle stochastic volatility
- Bring Heston model to life in order to test monte carlo methods on stochastic volatility models
- ~Enable monte_carlo() for custom fractional processes~
- Improve performance of jump diffusion processes
- Enable user's to utilise the appropriate monte carlo method when creating customised jump/fractional processes

Although these points are relevant, they will not be addressed as part of this PR to avoid scope screep.

