### PR TITLE
Basic support for Israel (Jewish) Calander

### DIFF
--- a/crates/RustQuant_time/Cargo.toml
+++ b/crates/RustQuant_time/Cargo.toml
@@ -20,7 +20,8 @@ RustQuant = { path = "../RustQuant" }
 [dependencies]
 RustQuant_iso = { workspace = true }
 RustQuant_utils = { workspace = true }
-reqwest = { version = "0.12.9", features = ["blocking"] }
+chrono = "0.4.38"
+heca-lib = "1.3.2"
 serde.workspace = true
 time = { workspace = true }
 

--- a/crates/RustQuant_time/Cargo.toml
+++ b/crates/RustQuant_time/Cargo.toml
@@ -20,8 +20,7 @@ RustQuant = { path = "../RustQuant" }
 [dependencies]
 RustQuant_iso = { workspace = true }
 RustQuant_utils = { workspace = true }
-chrono = "0.4.38"
-heca-lib = "1.3.2"
+icu = "1.5.0"
 serde.workspace = true
 time = { workspace = true }
 

--- a/crates/RustQuant_time/Cargo.toml
+++ b/crates/RustQuant_time/Cargo.toml
@@ -20,7 +20,8 @@ RustQuant = { path = "../RustQuant" }
 [dependencies]
 RustQuant_iso = { workspace = true }
 RustQuant_utils = { workspace = true }
-
+reqwest = { version = "0.12.9", features = ["blocking"] }
+serde.workspace = true
 time = { workspace = true }
 
 ## ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/crates/RustQuant_time/src/countries/middle_east/israel.rs
+++ b/crates/RustQuant_time/src/countries/middle_east/israel.rs
@@ -13,8 +13,8 @@
 
 use crate::calendar::Calendar;
 use crate::utilities::unpack_date;
-use serde::Deserialize;
 use reqwest::{blocking::Client, Error};
+use serde::Deserialize;
 use time::{Date, Weekday};
 use RustQuant_iso::*;
 
@@ -25,11 +25,10 @@ use RustQuant_iso::*;
 /// Israel a national holiday calendar.
 pub struct IsraelCalendar;
 
-
 // Two structs to capture response
 #[derive(Deserialize, Debug)]
 struct ResponseData {
-    items: Vec<Item>, 
+    items: Vec<Item>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -43,20 +42,19 @@ struct Item {
 
 fn jewish_holiday(date: &String) -> Result<bool, Error> {
     let url = "https://www.hebcal.com/hebcal";
-    
-    let params = [("v", "1"), ("cfg", "json"), ("maj", "on"), ("start", date), ("end", date)];
 
+    let params = [
+        ("v", "1"),
+        ("cfg", "json"),
+        ("maj", "on"),
+        ("start", date),
+        ("end", date),
+    ];
 
-    let response = Client::new()
-    .get(url)
-    .query(&params)
-    .send()
-    .map_err(|e| {
+    let response = Client::new().get(url).query(&params).send().map_err(|e| {
         eprintln!("Failed to send request: {}", e);
         e
     })?;
-
-    println!("{:?}", &response);
 
     let json: ResponseData = response.json().map_err(|e| {
         eprintln!("Failed to parse Json response: {}", e);
@@ -65,7 +63,6 @@ fn jewish_holiday(date: &String) -> Result<bool, Error> {
 
     Ok(!json.items.is_empty())
 }
-
 
 impl Calendar for IsraelCalendar {
     fn name(&self) -> &'static str {
@@ -83,9 +80,9 @@ impl Calendar for IsraelCalendar {
     fn is_holiday(&self, date: Date) -> bool {
         let (y, m, d, wd, yd, em) = unpack_date(date, false);
         let m = m as u8;
-        
+
         // Jewish weekend (Friday, Saturday)
-        if ( wd == Weekday::Friday || wd == Weekday::Saturday) {
+        if (wd == Weekday::Friday || wd == Weekday::Saturday) {
             return true;
         }
 

--- a/crates/RustQuant_time/src/countries/middle_east/israel.rs
+++ b/crates/RustQuant_time/src/countries/middle_east/israel.rs
@@ -27,10 +27,10 @@ use RustQuant_iso::*;
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 const JEWISH_HOLIDAYS: [(u8, u8); 19] = [
-    (12, 29),     // Jewish new year (Rosh Hashana) I
+    (12, 29),   // Jewish new year (Rosh Hashana) I
     (1, 1),     // Jewish new year (Rosh Hashana) II
     (1, 2),     // Jewish new year (Rosh Hashana) II
-    (1, 9),    // Yom Kippur I
+    (1, 9),     // Yom Kippur I
     (1, 10),    // Yom Kippur II
     (1, 14),    // Sukkot I 
     (1, 15),    // Sukkot II 
@@ -41,8 +41,8 @@ const JEWISH_HOLIDAYS: [(u8, u8); 19] = [
     (7, 15),    // Passover II
     (7, 20),    // Passover two I
     (7, 21),    // Passover two II
-    (8, 5),     // Memorial day
-    (8, 6),     // Independence day
+    (8, 4),     // Memorial day
+    (8, 5),     // Independence day
     (9, 5),     // Shavut I
     (9, 6),     // Shavut I
     (11, 9),    // Tisha Be'av
@@ -91,7 +91,7 @@ impl Calendar for IsraelCalendar {
             HebrewMonth::Shvat => 5,
             HebrewMonth::Adar => 6,
             HebrewMonth::Adar1 => 6,
-            HebrewMonth::Adar2 => 100, // Adar 2 is a leap-year month and never has a holiday. 100 is an arbitrary escape value.
+            HebrewMonth::Adar2 => 100, // Adar2 is a leap-year month and never has a holiday. 100 is an arbitrary escape value.
             HebrewMonth::Nissan => 7,
             HebrewMonth::Iyar => 8,
             HebrewMonth::Sivan => 9,
@@ -100,11 +100,7 @@ impl Calendar for IsraelCalendar {
             HebrewMonth::Elul => 12,
         };
 
-        let date_tuple: (u8, u8) = (month, hebrew_date.day().get() as u8); 
-        println!("{:?}", hebrew_date);
-        println!("{:?}", date_tuple);
-
-        JEWISH_HOLIDAYS.contains(&date_tuple)
+        JEWISH_HOLIDAYS.contains(&(month, hebrew_date.day().get() as u8))
     }
 }
 
@@ -138,15 +134,20 @@ mod test_israel {
     #[test]
     fn test_is_public_holiday() {
         let calendar = IsraelCalendar;
-        let purim = date!(2024 - 03 - 24); // Purim holiday 2024
-        let sukkot = date!(2024 - 10 - 17); // Sukkot holiday 2024
+        let purim = date!(2024 - 03 - 24);      // Purim holiday 2024
+        let sukkot = date!(2024 - 10 - 17);     // Sukkot holiday 2024
         let passover_23 = date!(2023 - 4 - 05); // Passover eve 2023
         let passover_24 = date!(2023 - 4 - 22); // Passover eve 2024
+        let shavuot_26 = date!(2026 - 5 - 22);  // Shavuot 2026
+        let memorial_26 = date!(2026 - 4 - 21); // Memorial day 2026
 
         assert!(!calendar.is_business_day(purim));
         assert!(!calendar.is_business_day(sukkot));
         assert!(!calendar.is_business_day(passover_23));
         assert!(!calendar.is_business_day(passover_24));
+        assert!(!calendar.is_business_day(shavuot_26));
+        assert!(!calendar.is_business_day(memorial_26));
+
     }
 
     // Test to verify if the is_business_day() method properly accounts for regular business days.

--- a/crates/RustQuant_time/src/countries/middle_east/israel.rs
+++ b/crates/RustQuant_time/src/countries/middle_east/israel.rs
@@ -1,0 +1,155 @@
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// RustQuant: A Rust library for quantitative finance tools.
+// Copyright (C) 2022-2024 https://github.com/avhz
+// Dual licensed under Apache 2.0 and MIT.
+// See:
+//      - LICENSE-APACHE.md
+//      - LICENSE-MIT.md
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// IMPORTS
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+use crate::calendar::Calendar;
+use crate::utilities::unpack_date;
+use serde::Deserialize;
+use reqwest::{blocking::Client, Error};
+use time::{Date, Weekday};
+use RustQuant_iso::*;
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// STRUCTS, ENUMS, TRAITS
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// Israel a national holiday calendar.
+pub struct IsraelCalendar;
+
+
+// Two structs to capture response
+#[derive(Deserialize, Debug)]
+struct ResponseData {
+    items: Vec<Item>, 
+}
+
+#[derive(Deserialize, Debug)]
+struct Item {
+    title: String,
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// IMPLEMENTATIONS, METHODS
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+fn jewish_holiday(date: &String) -> Result<bool, Error> {
+    let url = "https://www.hebcal.com/hebcal";
+    
+    let params = [("v", "1"), ("cfg", "json"), ("maj", "on"), ("start", date), ("end", date)];
+
+
+    let response = Client::new()
+    .get(url)
+    .query(&params)
+    .send()
+    .map_err(|e| {
+        eprintln!("Failed to send request: {}", e);
+        e
+    })?;
+
+    println!("{:?}", &response);
+
+    let json: ResponseData = response.json().map_err(|e| {
+        eprintln!("Failed to parse Json response: {}", e);
+        e
+    })?;
+
+    Ok(!json.items.is_empty())
+}
+
+
+impl Calendar for IsraelCalendar {
+    fn name(&self) -> &'static str {
+        "Israel"
+    }
+
+    fn country_code(&self) -> ISO_3166 {
+        ISRAEL
+    }
+
+    fn market_identifier_code(&self) -> ISO_10383 {
+        XTAE
+    }
+
+    fn is_holiday(&self, date: Date) -> bool {
+        let (y, m, d, wd, yd, em) = unpack_date(date, false);
+        let m = m as u8;
+        
+        // Jewish weekend (Friday, Saturday)
+        if ( wd == Weekday::Friday || wd == Weekday::Saturday) {
+            return true;
+        }
+
+        match jewish_holiday(&format!("{:04}-{:02}-{:02}", y, m, d)) {
+            Ok(is_holiday) => is_holiday,
+            Err(e) => {
+                eprintln!("Error checking Jewish holiday: {}", e);
+                false // default to non-holiday if there's an error
+            }
+        }
+    }
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// UNIT TESTS
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+#[cfg(test)]
+mod test_israel {
+    use super::*;
+    use time::macros::date;
+
+    // Test to verify the name() method.
+    #[test]
+    fn test_name() {
+        let calendar = IsraelCalendar;
+        assert_eq!(calendar.name(), "Israel");
+    }
+
+    // Test to verify if weekends are not considered business days.
+    #[test]
+    fn test_is_weekend() {
+        let calendar = IsraelCalendar;
+        let fri = date!(2023 - 01 - 27);
+        let sat = date!(2023 - 01 - 28);
+        assert!(!calendar.is_business_day(fri));
+        assert!(!calendar.is_business_day(sat));
+    }
+
+    // Test to verify if the is_business_day() method properly accounts for public holidays.
+    #[test]
+    fn test_is_public_holiday() {
+        let calendar = IsraelCalendar;
+        let purim = date!(2024 - 03 - 24); // Purim holiday 2024
+        let sukkot = date!(2024 - 10 - 17); // Sukkot holiday 2024
+        let passover_23 = date!(2023 - 4 - 05); // Passover eve 2023
+        let passover_24 = date!(2023 - 4 - 22); // Passover eve 2024
+
+        assert!(!calendar.is_business_day(purim));
+        assert!(!calendar.is_business_day(sukkot));
+        assert!(!calendar.is_business_day(passover_23));
+        assert!(!calendar.is_business_day(passover_24));
+    }
+
+    // Test to verify if the is_business_day() method properly accounts for regular business days.
+    #[test]
+    fn test_is_regular_business_day() {
+        let calendar = IsraelCalendar;
+        let regular_day1 = date!(2021 - 08 - 04);
+        let regular_day2 = date!(2024 - 04 - 09);
+        let regular_day3 = date!(2023 - 11 - 27);
+
+        assert!(calendar.is_business_day(regular_day1));
+        assert!(calendar.is_business_day(regular_day2));
+        assert!(calendar.is_business_day(regular_day3));
+    }
+}

--- a/crates/RustQuant_time/src/countries/mod.rs
+++ b/crates/RustQuant_time/src/countries/mod.rs
@@ -80,3 +80,9 @@ pub mod south_america {
     /// Chile holidays and calendars.
     pub mod chile;
 }
+
+/// Calanders implemented for Middle Eastern countries. 
+pub mod middle_east {
+    /// Israeli (Jewish) holidays and calander, implemented with an external API.
+    pub mod israel;
+}


### PR DESCRIPTION
Hey guys,

I added support for the Israeli stock exchange and Jewish calendar as in #142 .

The Israeli stock exchange follows Jewish calendar which isn't in sync with our usual Gregorian calendar, so every year the holiday dates shift (e.g. Passover eve was in April 5th 2023, but April 22nd on 2024). I tried to solve it using a call to an external API that answers if a given day is a holiday.

Please let me know what you think and provide lots of criticism! I'm trying to learn and want to progress to more issues. 

Also, I noticed that two utility tests don't pass (unrelated to my changes):

`test crates/RustQuant_time/src/utilities.rs - utilities::unpack_date (line 20) ... ignored`
`test crates/RustQuant_time/src/utilities.rs - utilities::leap_year_count (line 118) ... FAILED`
Should I look into it?