### PR TITLE
Feature implementations: Make Variable and Graph generic to support possible symbolic differentiation

### DIFF
--- a/crates/RustQuant_autodiff/Cargo.toml
+++ b/crates/RustQuant_autodiff/Cargo.toml
@@ -20,6 +20,7 @@ RustQuant = { path = "../RustQuant" }
 ndarray = { workspace = true }
 errorfunctions = { workspace = true }
 RustQuant_utils = { workspace = true }
+num-traits = "0.2.19"
 
 ## ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ## RUSTDOC CONFIGURATION

--- a/crates/RustQuant_autodiff/src/diff_traits.rs
+++ b/crates/RustQuant_autodiff/src/diff_traits.rs
@@ -1,0 +1,88 @@
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// RustQuant: A Rust library for quantitative finance tools.
+// Copyright (C) 2023 https://github.com/avhz
+// Dual licensed under Apache 2.0 and MIT.
+// See:
+//      - LICENSE-APACHE.md
+//      - LICENSE-MIT.md
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+use std::ops::{AddAssign, Neg};
+
+use num_traits::{NumOps, One, Zero};
+
+/// A nonadditive zero trait
+pub trait Initial: Sized {
+    /// return zero
+    fn zero() -> Self;
+}
+
+impl<T> Initial for T where T: Zero {
+    fn zero() -> Self {
+        Zero::zero()
+    }
+}
+
+/// A variable which can be evaluated upon by elementary operations.
+pub trait DiffOps:
+    NumOps + One + Zero + AddAssign + Neg<Output = Self> + Sized + Clone + Copy + NumOps<f64>
+{
+    /// Compute the derivative asin of the variable.
+    fn asin_diff(self) -> Self;
+    /// Compute the error function of the variable.
+    fn erf(self) -> Self;
+    /// Compute the complementary error function of the variable.
+    fn erfc(self) -> Self;
+    /// Compute the absolute value of the variable.
+    fn abs(self) -> Self;
+    /// Compute the signum of the variable.
+    fn signum(self) -> Self;
+    /// Compute the reciprocal of the variable.
+    fn recip(self) -> Self;
+    /// Compute the square root of the variable.
+    fn sqrt(self) -> Self;
+    /// Compute the cube root of the variable.
+    fn cbrt(self) -> Self;
+    /// Compute the integer power of the variable.
+    fn powi(self, n: i32) -> Self;
+    /// Compute the real power of the variable.
+    fn powf(self, other: Self) -> Self;
+    /// Compute the exponential of the variable.
+    fn exp(self) -> Self;
+    /// Compute the natural logarithm of the variable.
+    fn ln(self) -> Self;
+    /// Compute the natural logarithm of 1 + the variable.
+    fn ln_1p(self) -> Self;
+    /// Compute the exponential of the variable minus 1.
+    fn exp_m1(self) -> Self;
+    /// Compute the base 2 exponential of the variable.
+    fn exp2(self) -> Self;
+    /// Compute the binary logarithm of the variable.
+    fn log2(self) -> Self;
+    /// Compute the decimal logarithm of the variable.
+    fn log10(self) -> Self;
+    /// Compute the sine of the variable.
+    fn sin(self) -> Self;
+    /// Compute the cosine of the variable.
+    fn cos(self) -> Self;
+    /// Compute the tangent of the variable.
+    fn tan(self) -> Self;
+    /// Compute the arcsine of the variable.
+    fn asin(self) -> Self;
+    /// Compute the acosine of the variable.
+    fn acos(self) -> Self;
+    /// Compute the arctangent of the variable.
+    fn atan(self) -> Self;
+    /// Compute the sinh of the variable.
+    fn sinh(self) -> Self;
+    /// Compute the cosh of the variable.
+    fn cosh(self) -> Self;
+    /// Compute the tanh of the variable.
+    fn tanh(self) -> Self;
+    /// Compute the arcsinh of the variable.
+    fn asinh(self) -> Self;
+    /// Compute the arccosh of the variable.
+    fn acosh(self) -> Self;
+    /// Compute the atanh of the variable.
+    fn atanh(self) -> Self;
+}

--- a/crates/RustQuant_autodiff/src/graph.rs
+++ b/crates/RustQuant_autodiff/src/graph.rs
@@ -17,7 +17,9 @@
 // IMPORTS
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use crate::{variable::Variable, Arity, Vertex};
+use num_traits::Zero;
+
+use crate::{variable::Variable, Arity, DiffOps, Initial, Vertex};
 use std::cell::RefCell;
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -26,9 +28,9 @@ use std::cell::RefCell;
 
 /// Struct to contain the graph (Wengert list), as a vector of `Vertex`s.
 #[derive(Debug, Clone)]
-pub struct Graph {
+pub struct Graph<T = f64> {
     /// Vector containing the vertices in the Wengert List.
-    pub vertices: RefCell<Vec<Vertex>>,
+    pub vertices: RefCell<Vec<Vertex<T>>>,
 }
 // pub struct Graph(RefCell<Rc<[Vertex]>>);
 
@@ -40,7 +42,7 @@ impl Default for Graph {
 }
 
 /// Implementation for the `Graph` struct.
-impl Graph {
+impl<T> Graph<T> where T: Initial + Clone + Copy {
     /// Instantiate a new graph.
     #[must_use]
     #[inline]
@@ -74,7 +76,7 @@ impl Graph {
     /// Add a new variable to the graph.
     /// Returns a new `Variable` instance (the contents of a vertex).
     #[inline]
-    pub fn var(&self, value: f64) -> Variable {
+    pub fn var(&self, value: T) -> Variable<T> {
         Variable {
             graph: self,
             value,
@@ -85,8 +87,8 @@ impl Graph {
     /// Add multiple variables (a slice) to the graph.
     /// Useful for larger functions with many inputs.
     #[inline]
-    pub fn vars<'v>(&'v self, values: &[f64]) -> Vec<Variable<'v>> {
-        values.iter().map(|&val| self.var(val)).collect()
+    pub fn vars<'v>(&'v self, values: &[T]) -> Vec<Variable<'v, T>> {
+        values.iter().map(|val| self.var(val.clone())).collect()
     }
 
     /// Returns the length of the graph so new vertices can index to the correct position.
@@ -113,7 +115,7 @@ impl Graph {
         self.vertices
             .borrow_mut()
             .iter_mut()
-            .for_each(|vertex| vertex.partials = [0.0; 2]);
+            .for_each(|vertex| vertex.partials = [T::zero(), T::zero()]);
     }
 
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -122,7 +124,7 @@ impl Graph {
 
     /// Pushes a vertex to the graph.
     #[inline]
-    pub fn push(&self, arity: Arity, parents: &[usize], partials: &[f64]) -> usize {
+    pub fn push(&self, arity: Arity, parents: &[usize], partials: &[T]) -> usize {
         let mut vertices = self.vertices.borrow_mut();
         let len = vertices.len();
 
@@ -140,7 +142,7 @@ impl Graph {
                 assert!(parents.is_empty());
 
                 Vertex {
-                    partials: [0.0, 0.0],
+                    partials: [T::zero(), T::zero()],
                     parents: [len, len],
                 }
             }
@@ -157,7 +159,7 @@ impl Graph {
                 assert!(parents.len() == 1);
 
                 Vertex {
-                    partials: [partials[0], 0.0],
+                    partials: [partials[0], T::zero()],
                     parents: [parents[0], len],
                 }
             }

--- a/crates/RustQuant_autodiff/src/lib.rs
+++ b/crates/RustQuant_autodiff/src/lib.rs
@@ -91,6 +91,14 @@ pub use vertex::*;
 pub mod overload;
 pub use overload::*;
 
+/// `DiffOps`s for `autodiff`.
+pub mod diff_traits;
+pub use diff_traits::*;
+
+/// `Symbol`s for `autodiff`.
+pub mod symbol;
+pub use symbol::*;
+
 /// `Variable`s for `autodiff`.
 pub mod variable;
 pub use variable::*;

--- a/crates/RustQuant_autodiff/src/symbol.rs
+++ b/crates/RustQuant_autodiff/src/symbol.rs
@@ -1,0 +1,30 @@
+use std::f64::consts::PI;
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// RustQuant: A Rust library for quantitative finance tools.
+// Copyright (C) 2023 https://github.com/avhz
+// Dual licensed under Apache 2.0 and MIT.
+// See:
+//      - LICENSE-APACHE.md
+//      - LICENSE-MIT.md
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+use crate::Initial;
+
+/// A symbolic expression.
+#[derive(Debug, Clone, Copy)]
+pub enum Expression {
+    /// A constant real value.
+    Constant(f64),
+    /// A variable.
+    Variable(&'static str),
+    /// A function applied to an expression, where the positive integer is the index of the expression on the graph.
+    Unary(&'static str, usize),
+    /// A function applied to two expressions.
+    Binary(&'static str, usize, usize),
+}
+
+impl Initial for Expression {
+    fn zero() -> Self {
+        Self::Constant(0.0)
+    }
+}

--- a/crates/RustQuant_autodiff/src/variable.rs
+++ b/crates/RustQuant_autodiff/src/variable.rs
@@ -18,29 +18,76 @@
 // IMPORTS
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use crate::graph::Graph;
+
+use RustQuant_utils::forward;
+
+use crate::{graph::Graph, DiffOps};
 use std::fmt::Display;
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // STRUCT AND IMPLEMENTATION
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+impl DiffOps for f64 {
+    fn asin_diff(self) -> f64 {
+        if (self > -1.0) && (self < 1.0) {
+            ((1.0 - self.powi(2)).sqrt()).recip()
+        } else {
+            f64::NAN
+        }
+    }
+    fn erfc(self) -> f64 {
+        1.0 - self.erf()
+    }
+    fn erf(self) -> f64 {
+        errorfunctions::RealErrorFunctions::erf(self)
+    }
+    forward! {
+        Self::abs(self) -> Self;
+        Self::signum(self) -> Self;
+        Self::recip(self) -> Self;
+        Self::powi(self, n: i32) -> Self;
+        Self::sqrt(self) -> Self;
+        Self::cbrt(self) -> Self;
+        Self::powf(self, n: Self) -> Self;
+        Self::ln_1p(self) -> Self;
+        Self::exp_m1(self) -> Self;
+        Self::exp2(self) -> Self;
+        Self::log2(self) -> Self;
+        Self::log10(self) -> Self;
+        Self::exp(self) -> Self;
+        Self::ln(self) -> Self;
+        Self::sin(self) -> Self;
+        Self::cos(self) -> Self;
+        Self::tan(self) -> Self;
+        Self::asin(self) -> Self;
+        Self::acos(self) -> Self;
+        Self::atan(self) -> Self;
+        Self::sinh(self) -> Self;
+        Self::cosh(self) -> Self;
+        Self::tanh(self) -> Self;
+        Self::asinh(self) -> Self;
+        Self::acosh(self) -> Self;
+        Self::atanh(self) -> Self;
+    }
+}
+
 /// Struct to contain the initial variables.
 #[derive(Clone, Copy, Debug)]
-pub struct Variable<'v> {
+pub struct Variable<'v, T = f64> {
     /// Pointer to the graph.
-    pub graph: &'v Graph,
+    pub graph: &'v Graph<T>,
     /// Index to the vertex.
     pub index: usize,
     /// Value associated to the vertex.
-    pub value: f64, // Value,
+    pub value: T, // Value,
 }
 
-impl<'v> Variable<'v> {
+impl<'v, T: Copy> Variable<'v, T> {
     /// Instantiate a new variable.
     #[must_use]
     #[inline]
-    pub const fn new(graph: &'v Graph, index: usize, value: f64) -> Self {
+    pub const fn new(graph: &'v Graph<T>, index: usize, value: T) -> Self {
         Variable {
             graph,
             index,
@@ -51,7 +98,7 @@ impl<'v> Variable<'v> {
     /// Function to return the value contained in a vertex.
     #[must_use]
     #[inline]
-    pub fn value(&self) -> f64 {
+    pub fn value(&self) -> T {
         self.value
     }
 
@@ -65,10 +112,12 @@ impl<'v> Variable<'v> {
     /// Function to return the graph.
     #[must_use]
     #[inline]
-    pub fn graph(&self) -> &'v Graph {
+    pub fn graph(&self) -> &'v Graph<T> {
         self.graph
     }
+}
 
+impl<'v> Variable<'v, f64> {
     /// Check if variable is finite.
     #[must_use]
     #[inline]

--- a/crates/RustQuant_autodiff/src/vertex.rs
+++ b/crates/RustQuant_autodiff/src/vertex.rs
@@ -9,6 +9,8 @@
 
 use std::fmt;
 
+use crate::DiffOps;
+
 /// Struct defining the vertex of the computational graph.
 ///
 /// Operations are assumed to be binary (e.g. x + y),
@@ -16,9 +18,9 @@ use std::fmt;
 /// To deal with unary or nullary operations, we just adjust the weights
 /// (partials) and the dependencies (parents).
 #[derive(Clone, Copy, Debug)]
-pub struct Vertex {
+pub struct Vertex<T = f64> {
     /// Array that contains the partial derivatives wrt to x and y.
-    pub partials: [f64; 2],
+    pub partials: [T; 2],
 
     /// Array that contains the indices of the parent vertices.
     pub parents: [usize; 2],

--- a/crates/RustQuant_utils/src/lib.rs
+++ b/crates/RustQuant_utils/src/lib.rs
@@ -36,6 +36,19 @@ macro_rules! assert_approx_equal {
     };
 }
 
+/// Forward a method call to the struct.
+#[macro_export]
+macro_rules! forward {
+    ($( Self :: $method:ident ( self $( , $arg:ident : $ty:ty )* ) -> $ret:ty ; )*) => {
+        $(
+            #[inline]
+            fn $method(self $( , $arg : $ty )* ) -> $ret {
+                Self::$method(self $( , $arg )* )
+            }
+        )*
+    };
+}
+
 /// Plot a vector of values.
 #[macro_export]
 macro_rules! plot_vector {


### PR DESCRIPTION
Hi @avhz . Thanks for writing and open sourcing this project. 

I would like to add symbolic differentiation capabilities to the autodiff subcrate.
There are a couple of rust-autodiff packages out there but none look as actively maintained as your package.
My end goal here is to have a procedural macro for compile-time autodiffed code generation, so that I can have autodiff without a on-heap computation graph.

This PR just extends a bunch of generic typing to the Graph/Vertex/Variable structs to support the possibility of putting expressions to Graphs. I'd be glad to hear your thoughts!