### PR TITLE
quote.rs - documentation improvement and small fix

### DIFF
--- a/crates/RustQuant_cashflows/src/quotes.rs
+++ b/crates/RustQuant_cashflows/src/quotes.rs
@@ -50,6 +50,7 @@ impl SimpleQuote {
     pub fn set_value(&mut self, value: Option<f64>) -> f64 {
         let diff = match (&self.value, &value) {
             (Some(old_value), Some(new_value)) => new_value - old_value,
+            (None, Some(new_value)) => *new_value,
             _ => 0.0,
         };
 
@@ -62,9 +63,24 @@ impl SimpleQuote {
         diff
     }
 
-    /// Reset the quote value.
+    /// Resets the value of the quote to `None`.
+    ///
+    /// This method clears the current value of the quote, effectively making it invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use RustQuant::money::{Quote, SimpleQuote};
+    ///
+    /// let mut quote = SimpleQuote::new(Some(10.0));
+    /// assert!(quote.is_valid());
+    ///
+    /// quote.reset();
+    /// assert!(!quote.is_valid());
+    /// assert_eq!(quote.value(), None);
+    /// ```
     pub fn reset(&mut self) {
-        self.set_value(None);
+        self.value = None;
     }
 }
 

--- a/crates/RustQuant_cashflows/src/quotes.rs
+++ b/crates/RustQuant_cashflows/src/quotes.rs
@@ -27,7 +27,26 @@ impl SimpleQuote {
         SimpleQuote { value }
     }
 
-    /// Set the quote value.
+    /// Sets the value of the quote and returns the difference between the new value and the old value.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - An optional new value to set.
+    ///
+    /// # Returns
+    ///
+    /// * `f64` - The difference between the new value and the old value. If either the old value or the
+    ///   new value is not present, the difference will be 0.0.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use RustQuant::money::SimpleQuote;
+    ///
+    /// let mut quote = SimpleQuote::new(Some(10.0));
+    /// let diff = quote.set_value(Some(15.0));
+    /// assert_eq!(diff, 5.0);
+    /// ```
     pub fn set_value(&mut self, value: Option<f64>) -> f64 {
         let diff = match (&self.value, &value) {
             (Some(old_value), Some(new_value)) => new_value - old_value,

--- a/crates/RustQuant_cashflows/src/quotes.rs
+++ b/crates/RustQuant_cashflows/src/quotes.rs
@@ -35,8 +35,8 @@ impl SimpleQuote {
     ///
     /// # Returns
     ///
-    /// * `f64` - The difference between the new value and the old value. If either the old value or the
-    ///   new value is not present, the difference will be 0.0.
+    /// * `f64` - The difference between the new value and the old value. If the new value is not present,
+    ///  the difference will be 0.0.
     ///
     /// # Examples
     ///

--- a/crates/RustQuant_cashflows/src/quotes.rs
+++ b/crates/RustQuant_cashflows/src/quotes.rs
@@ -41,7 +41,7 @@ impl SimpleQuote {
     /// # Examples
     ///
     /// ```rust
-    /// use RustQuant::money::SimpleQuote;
+    /// use RustQuant::cashflows::SimpleQuote;
     ///
     /// let mut quote = SimpleQuote::new(Some(10.0));
     /// let diff = quote.set_value(Some(15.0));
@@ -70,7 +70,7 @@ impl SimpleQuote {
     /// # Examples
     ///
     /// ```rust
-    /// use RustQuant::money::{Quote, SimpleQuote};
+    /// use RustQuant::cashflows::{Quote, SimpleQuote};
     ///
     /// let mut quote = SimpleQuote::new(Some(10.0));
     /// assert!(quote.is_valid());


### PR DESCRIPTION
Hi there! 👋 

I’ve been experimenting with the library and noticed that the `set_value` function of `SimpleQuote` could use a bit more clarity in its documentation. Since the function returns the difference, I thought it would be helpful to make that more explicit.

Additionally, I spotted an issue where the `reset` function wasn’t resetting the value of the quote due to the match arm. I’ve included a fix for that as well.

Looking forward to your feedback—hope this helps! 