### PR TITLE
B-Spline Interpolation Implementation

### DIFF
--- a/crates/RustQuant_error/src/lib.rs
+++ b/crates/RustQuant_error/src/lib.rs
@@ -115,6 +115,14 @@ pub enum RustQuantError {
     /// Outside of interpolation range.
     #[error("Outside of interpolation range.")]
     OutsideOfRange,
+
+    /// Inconsistent B-Spline parameter lengths.
+    #[error("For {0} control points and degree {1}, we need {0} + {1} + 1 ({2}) knots.")]
+    BSplineInvalidParameters(usize, usize, usize),
+
+    /// Outside of B-Spline interpolation range.
+    #[error("{0}")]
+    BSplineOutsideOfRange(String),
 }
 
 /// Curve error enum.

--- a/crates/RustQuant_math/src/interpolation/b_splines.rs
+++ b/crates/RustQuant_math/src/interpolation/b_splines.rs
@@ -208,19 +208,31 @@ mod tests_b_splines {
 
     #[test]
     fn test_b_spline_inconsistent_parameters() {
-        let knots = vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7];
-        let control_points = vec![0., 1., 0., 1., 0., 1., 0.];
-        
-        assert!(BSplineInterpolator::new(knots, control_points, 3).is_err())
+        let knots = vec![0.0, 1.0, 2.0, 3.0, 4.0,];
+        let control_points = vec![-1.0, 2.0, 0.0, -1.0];
+
+        match BSplineInterpolator::new(knots.clone(), control_points.clone(), 2) {
+            Ok(_) => panic!("Constructor did not throw an error!"),
+            Err(e) => assert_eq!(
+                e.to_string(),
+                "For 4 control points and degree 2, we need 4 + 2 + 1 (7) knots."
+            )
+        }
     }
 
     #[test]
     fn test_b_spline_out_of_range() {
-        let knots = vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1];
-        let control_points = vec![0., 1., 0., 1., 0., 1., 0.];
-        let mut interpolator = BSplineInterpolator::new(knots, control_points, 3).unwrap();
+        let knots = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let control_points = vec![-1.0, 2.0, 0.0, -1.0];
+        let mut interpolator = BSplineInterpolator::new(knots, control_points, 2).unwrap();
         let _ = interpolator.fit();
 
-        assert!(interpolator.interpolate(0.95).is_err());
+        match interpolator.interpolate(5.5) {
+            Ok(_) => panic!("Interpolation should have failed!"),
+            Err(e) => assert_eq!(
+                e.to_string(),
+                "Point 5.5 is outside of the interpolation range [2, 4]"
+            )
+        }
     }
 }

--- a/crates/RustQuant_math/src/interpolation/b_splines.rs
+++ b/crates/RustQuant_math/src/interpolation/b_splines.rs
@@ -64,7 +64,7 @@ where
         }
 
         knots.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        // println!("Knots: {:?}", knots);
+
         Ok(Self {
             knots,
             control_points,

--- a/crates/RustQuant_math/src/interpolation/b_splines.rs
+++ b/crates/RustQuant_math/src/interpolation/b_splines.rs
@@ -1,0 +1,100 @@
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// RustQuant: A Rust library for quantitative finance tools.
+// Copyright (C) 2023 https://github.com/avhz
+// Dual licensed under Apache 2.0 and MIT.
+// See:
+//      - LICENSE-APACHE.md
+//      - LICENSE-MIT.md
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+//! Module containing functionality for interpolation.
+
+use crate::interpolation::{InterpolationIndex, InterpolationValue, Interpolator};
+use RustQuant_error::RustQuantError;
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// STRUCTS & ENUMS
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// B-Spline Interpolator.
+pub struct BSplineInterpolator<IndexType, ValueType>
+where
+    IndexType: InterpolationIndex<DeltaDiv = ValueType>,
+    ValueType: InterpolationValue,
+{
+    /// Knots of the B-Spline.
+    pub knots: Vec<IndexType>,
+
+    /// Control points of the B-Spline.
+    pub control_points: Vec<ValueType>,
+
+    /// Degree of B-Spline.
+    pub degree: usize,
+
+    /// Whether the interpolator has been fitted.
+    pub fitted: bool,
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// IMPLEMENTATIONS, FUNCTIONS, AND MACROS
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+impl<IndexType, ValueType> BSplineInterpolator<IndexType, ValueType>
+where
+    IndexType: InterpolationIndex<DeltaDiv = ValueType>,
+    ValueType: InterpolationValue,
+{
+    /// Create a new BSplineInterpolator.
+    ///
+    /// # Errors
+    /// - `RustQuantError::UnequalLength` if ```xs.length() != ys.length()```.
+    ///
+    /// # Panics
+    /// Panics if NaN is in the index.
+    pub fn new(
+        mut knots: Vec<IndexType>,
+        control_points: Vec<ValueType>,
+        degree: usize
+    ) -> Result<BSplineInterpolator<IndexType, ValueType>, RustQuantError> {
+
+        if knots.len() != control_points.len() + degree + 1 {
+            return Err(RustQuantError::BSplineInvalidParameters(
+                control_points.len(), degree, control_points.len() + degree + 1,
+            ));
+        }
+
+        knots.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        // println!("Knots: {:?}", knots);
+        Ok(Self {
+            knots,
+            control_points,
+            degree,
+            fitted: false,
+        })
+    }
+
+    /// Cox de Boor algorithm to evalute the spline curves.
+    fn cox_de_boor(&self, point: IndexType, index: usize, degree: usize) -> ValueType {
+        if degree == 0 {
+            return if point.ge(&self.knots[index]) && point.lt(&self.knots[index + 1]) {
+                ValueType::one()
+            } else {
+                ValueType::zero()
+            }
+        }
+    
+        let mut left_term: ValueType = ValueType::zero();
+        let mut right_term: ValueType = ValueType::zero();
+    
+        if self.knots[index + degree] != self.knots[index] {
+            left_term = ((point - self.knots[index]) / (self.knots[index + degree] - self.knots[index]))
+                * self.cox_de_boor(point, index, degree - 1);
+        }
+    
+        if self.knots[index + degree + 1] != self.knots[index + 1] {
+            right_term = ((self.knots[index + degree + 1] - point) / (self.knots[index + degree + 1] - self.knots[index + 1]))
+                * self.cox_de_boor(point, index + 1, degree - 1);
+        }
+        left_term + right_term
+    }
+}

--- a/crates/RustQuant_math/src/interpolation/b_splines.rs
+++ b/crates/RustQuant_math/src/interpolation/b_splines.rs
@@ -153,7 +153,7 @@ mod tests_b_splines {
         let knots = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let control_points = vec![-1.0, 2.0, 0.0, -1.0];
         
-        let mut interpolator = BSplineInterpolator::new(knots.clone(), control_points.clone(), 2).unwrap();
+        let mut interpolator = BSplineInterpolator::new(knots, control_points, 2).unwrap();
         let _ = interpolator.fit();
 
         assert_approx_equal!(
@@ -168,7 +168,7 @@ mod tests_b_splines {
         let knots = vec![0.0, 1.0, 3.0, 4.0, 6.0, 7.0, 8.0, 10.0, 11.0];
         let control_points = vec![2.0, -1.0, 1.0, 0.0, 1.0];
         
-        let mut interpolator = BSplineInterpolator::new(knots.clone(), control_points.clone(), 3).unwrap();
+        let mut interpolator = BSplineInterpolator::new(knots, control_points, 3).unwrap();
         let _ = interpolator.fit();
 
         assert_approx_equal!(

--- a/crates/RustQuant_math/src/interpolation/mod.rs
+++ b/crates/RustQuant_math/src/interpolation/mod.rs
@@ -16,6 +16,9 @@ pub use linear_interpolator::*;
 pub mod exponential_interpolator;
 pub use exponential_interpolator::*;
 
+pub mod b_splines;
+pub use b_splines::*;
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/crates/RustQuant_math/src/interpolation/mod.rs
+++ b/crates/RustQuant_math/src/interpolation/mod.rs
@@ -7,7 +7,7 @@
 //      - LICENSE-MIT.md
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-use std::ops::{Div, Mul, Sub};
+use std::ops::{Div, Mul, Sub, AddAssign};
 use RustQuant_error::RustQuantError;
 
 pub mod linear_interpolator;
@@ -20,11 +20,11 @@ pub use exponential_interpolator::*;
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Trait describing requirements to be interpolated.
-pub trait InterpolationValue: num::Num + std::fmt::Debug + Copy + Clone + Sized {}
+pub trait InterpolationValue: num::Num + AddAssign + std::fmt::Debug + Copy + Clone + Sized {}
 
 /// Trait describing requirements to be an index of interpolation.
 pub trait InterpolationIndex:
-    Sub<Self, Output = Self::Delta> + PartialOrd + Copy + Clone + Sized
+    Sub<Self, Output = Self::Delta> + PartialOrd + Copy + Clone + Sized + std::fmt::Display
 {
     /// Type of the difference of `Self` - `Self`
     type Delta: Div<Self::Delta, Output = Self::DeltaDiv>
@@ -60,7 +60,7 @@ where
     fn add_point(&mut self, point: (IndexType, ValueType));
 }
 
-impl<T> InterpolationValue for T where T: num::Num + std::fmt::Debug + Copy + Clone + Sized {}
+impl<T> InterpolationValue for T where T: num::Num + AddAssign + std::fmt::Debug + Copy + Clone + Sized {}
 
 macro_rules! impl_interpolation_index {
     ($a:ty, $b:ty, $c:ty) => {


### PR DESCRIPTION
This pull request is to address issue https://github.com/avhz/RustQuant/issues/5 and is part of the roadmap to v1 (https://github.com/avhz/RustQuant/issues/187).

# B-Splines

B-splines are constructed by joining polynomials of degree $d$, resulting in a curve with continuity $C^{d-1}$.

For a B-spline of degree $d$, we define a set of control points:

$$C= [c_0, c_1, \ldots, c_{k-1}]$$

We also define a non-decreasing sequence of knots:

$$T = [t_0, t_1, \ldots, t_{k+d}]$$

where we require a total of $d + k + 1$ knots.

The basis functions are defined as follows:

$$
N_{i, 0}(t) = \begin{cases} 
      1 & t\in[t_i, t_{i+1}) \\
      0 & \text{otherwise}
   \end{cases}
$$

$$
N_{i, d}(t) = \frac{t-t_i}{t_{i + d} - t_{i}} B_{i, d-1}(t) + \frac{t_{i+d+1} - t}{t_{i+d+1} - t_{i+1}} B_{i+1, d-1}(t)
$$

for $i\in\set{0,1,\ldots,k+d-1}$.

The basis functions $B_{i, d}(t)$ for $d>0$ can be evaluated via the [Cox de Boor algorithm](https://en.wikipedia.org/wiki/De_Boor%27s_algorithm).

The splines are then constructed as follows (mathematical notation could not be rendered, so an image has been included instead):

<img width="150" alt="Screenshot 2025-04-14 at 23 07 20" src="https://github.com/user-attachments/assets/4d3cc380-e832-44aa-b786-0aa822f7e093" />

The B-spline defined above can only be evaluated within the interval $t\in[t_{d}, t_{k}]$.

# Implementation

A B-spline configuration can be set up as follows:

```rust
use RustQuant::math::interpolation::BSplineInterpolator;

let knots = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
let control_points = vec![-1.0, 2.0, 0.0, -1.0];

let mut interpolator = BSplineInterpolator::new(knots, control_points.clone(), 2).unwrap();
let _ = interpolator.fit();
```

An approximation can then be performed:

```rust
println!("{}", interpolator.interpolate(2.5).unwrap()); // 1.375
```

If the length of the knot vector does not align with the number of control points and the degree, an error will be raised:

```rust
use RustQuant::math::interpolation::BSplineInterpolator;

let knots = vec![0.0, 1.0, 2.0, 3.0, 4.0,];
let control_points = vec![-1.0, 2.0, 0.0, -1.0];
match BSplineInterpolator::new(knots.clone(), control_points.clone(), 2) {
            Ok(_) => {}
            Err(e) => println!("{}", e.to_string()), // For 4 control points and degree 2, we need 4 + 2 + 1 (7) knots.
}

```

Additionally, the domain over which you can perform approximations is limited, as mentioned earlier:

```rust
let knots = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
let control_points = vec![-1.0, 2.0, 0.0, -1.0];
let mut interpolator = BSplineInterpolator::new(knots, control_points, 2).unwrap();
let _ = interpolator.fit();

match interpolator.interpolate(5.5) {
            Ok(_) => {},
            Err(e) => println!("{}", e.to_string()) // Point 5.5 is outside of the interpolation range [2, 4]
            )
        }
    }
```

## Notes:

- The `add_point()` method places the "x-axis" coordinate into its appropriate position within the knots vector, maintaining its sorted order. However, the corresponding "y-axis" value is appended to the end of the control_points vector, since the ordering of control points is independent of the knot values and is instead determined by the fitting process.

- Some of the unit tests were benchmarked against SciPy’s `BSpline()` implementation to verify that the functionality behaves as expected.
